### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,17 @@ already be built. Use `make binary` to skip building the man pages, or install
 
 Equivalent options for enabling/disabling features are available when using the CMake build.
 
+### Building mosquitto - Using vcpkg
+
+You can download and install mosquitto using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install mosquitto
+
+The mosquitto port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 ## Credits
 


### PR DESCRIPTION
Mosquitto is available as a port in vcpkg, a C++ library manager that simplifies installation for mosquitto and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build mosquitto, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.