### PR TITLE
Update documentation

### DIFF
--- a/docker/2.0-openssl/README.md
+++ b/docker/2.0-openssl/README.md
@@ -33,6 +33,19 @@ to expose the ports that have been configured, for example:
 docker run -it -p 1883:1883 -p 8080:8080 -v <absolute-path-to-configuration-file>:/mosquitto/config/mosquitto.conf eclipse-mosquitto:<version>
 ```
 
+**Important**: The default configuration only listens on the loopback
+interface. This means that there is no way to access Mosquitto in the docker
+container without using a custom configuration containing at least a listener.
+You also need to make a decision to allow anonymous connections or to set up a
+different method of client authentication.
+
+i.e. to configure a Mosquitto docker container as if it was running locally,
+add the following to `mosquitto.conf`:
+```
+listener 1883
+allow_anonymous true
+```
+
 Configuration can be changed to:
 
 * persist data to `/mosquitto/data`

--- a/docker/2.0/README.md
+++ b/docker/2.0/README.md
@@ -33,6 +33,20 @@ to expose the ports that have been configured, for example:
 docker run -it -p 1883:1883 -p 8080:8080 -v <absolute-path-to-configuration-file>:/mosquitto/config/mosquitto.conf eclipse-mosquitto:<version>
 ```
 
+
+**Important**: The default configuration only listens on the loopback
+interface. This means that there is no way to access Mosquitto in the docker
+container without using a custom configuration containing at least a listener.
+You also need to make a decision to allow anonymous connections or to set up a
+different method of client authentication.
+
+i.e. to configure a Mosquitto docker container as if it was running locally,
+add the following to `mosquitto.conf`:
+```
+listener 1883
+allow_anonymous true
+```
+
 Configuration can be changed to:
 
 * persist data to `/mosquitto/data`

--- a/docker/generic/README.md
+++ b/docker/generic/README.md
@@ -45,3 +45,16 @@ docker run -it -p 1883:1883 -v <path-to-configuration-file>:/mosquitto/config/mo
 :boom: if the mosquitto configuration (mosquitto.conf) was modified
 to use non-default ports, the docker run command will need to be updated
 to expose the ports that have been configured.
+
+**Important**: The default configuration only listens on the
+loopback interface. This means that there is no way to access Mosquitto in the
+docker container without using a custom configuration containing at least
+a listener. You also need to make a decision to allow anonymous connections or
+to set up a different method of client authentication.
+
+i.e. to configure a Mosquitto docker container as if it was running locally,
+add the following to `mosquitto.conf`:
+```
+listener 1883
+allow_anonymous true
+```


### PR DESCRIPTION
Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----

This pull request addresses some documentation changes regarding the migration to 2.0 and beyond.
There is also some discussion around this in #2074 and #2040. 

I will repeat here that while I agree that it's a great idea to only bind to the loopback interface by default, restricting the listener to localhost inside a docker container serves no benefit at all. It forces users to always define a mosquitto.conf. And even if mosquitto binds to every address within a docker container, it is still up to the user of the container to bind this port to their own network with e.g. `-p 1883:1883`.
Additionally, users need now also to explicitly allow anonymous users, or set up proper user authentication.