### PR TITLE
Fixes db_dump build issue with old gcc (4.5.1)

### DIFF
--- a/apps/db_dump/Makefile
+++ b/apps/db_dump/Makefile
@@ -20,6 +20,10 @@ OBJS = \
 	   topic_tok.o \
 	   utf8_mosq.o
 
+ifeq ($(UNAME),Linux)
+    LIBS:=$(LIBS) -lrt
+endif
+
 .PHONY: all clean reallyclean
 
 all : mosquitto_db_dump


### PR DESCRIPTION
This fixes db_dump build issue with old gcc (4.5.1)