### PR TITLE
- Correlation data

### DIFF
--- a/client/client_shared.h
+++ b/client/client_shared.h
@@ -129,6 +129,8 @@ struct mosq_config {
 	mosquitto_property *will_props;
 	bool have_topic_alias; /* pub */
 	char *response_topic; /* rr */
+	void *correlation_data; /* rr */
+	int correlation_datalen; /* rr */
 	bool tcp_nodelay;
 };
 

--- a/client/rr_client.c
+++ b/client/rr_client.c
@@ -84,6 +84,19 @@ static void my_message_callback(struct mosquitto *mosq, void *obj, const struct 
 	UNUSED(obj);
 	UNUSED(properties);
 
+	if (cfg.correlation_data) {
+		void *value;
+		uint16_t len;
+		if (!mosquitto_property_read_binary(properties, MQTT_PROP_CORRELATION_DATA, &value, &len, false)) {
+			printf("skipped message with empty correlation data\n");
+			return;
+		}
+		if (len != cfg.correlation_datalen || memcmp(value, cfg.correlation_data, len)) {
+			printf("skipped message with invalid correlation data\n");
+			return;
+		}
+	}
+
 	print_message(&cfg, message, properties);
 	switch(cfg.pub_mode){
 		case MSGMODE_CMD:
@@ -195,7 +208,7 @@ static void print_usage(void)
 	printf("             with v3.1.1 brokers.\n");
 	printf("mosquitto_rr version %s running on libmosquitto %d.%d.%d.\n\n", VERSION, major, minor, revision);
 	printf("Usage: mosquitto_rr {[-h host] [--unix path] [-p port] [-u username] [-P password] -t topic | -L URL} -e response-topic\n");
-	printf("                    [-c] [-k keepalive] [-q qos] [-R] [-x session-expiry-interval\n");
+	printf("                    [-c] [-k keepalive] [-q qos] [-R] [-x session-expiry-interval] [-C]\n");
 	printf("                    [-F format]\n");
 #ifndef WIN32
 	printf("                    [-W timeout_secs]\n");
@@ -230,6 +243,7 @@ static void print_usage(void)
 	printf("      for the same client id when the client connects, and sessions will never expire when the\n");
 	printf("      client disconnects. MQTT v5 clients can change their session expiry interval with the -x\n");
 	printf("      argument.\n");
+	printf(" -C : Generates random correlation data and match response.\n");
 	printf(" -d : enable debug messages.\n");
 	printf(" -D : Define MQTT v5 properties. See the documentation for more details.\n");
 	printf(" -e : Response topic. The client will subscribe to this topic to wait for a response.\n");


### PR DESCRIPTION
Hello,
From the [detailed description](https://www.hivemq.com/blog/mqtt5-essentials-part9-request-response-pattern/) of the request-response support, it is still not fully clear to me if every RPC call must/should have a different unique response topic, or if the same response topic could be reused, and the correlation-data should be used instead to match response with the original request instance.

Generally speaking, using a unique response topic (e.g. appending a UID to it) it is equivalent to use a random correlation data. I can however see the correlation data as a logical "extension" to the response topic: for example, the response topic ID can be generated by a client at startup and used for all the subsequent requests. In that case, every request will have a different correlation data.

In any case, I noticed that the `mosquitto_rr` client doesn't support correlation-data check when a message is received. In case of persistent topics, subsequent calls with the same response topic will always hit the previous cached response, without waiting for the new correct response.

I propose a simple switch for the `mosquitto_rr` client that always generates a random correlation data, and then it filters the response message until the right correlation data is received.
The PR is simple and it always generating a fixed-size correlation data using random bytes. Please let me know if you think that some additional input should be taken instead (e.g. buffer size, exact array content, etc...).

I chosen the `-C` boolean switch for that, let me know if you think something different should be used instead.

I didn't found any test related to the `mosquitto_rr` client, but only to `pub` and `sub` clients.

Thanks! L.


- [X] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [X] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [X] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run `make test` with your changes locally?

