### PR TITLE
add stdout option to mosquitto_passwd

### DIFF
--- a/apps/mosquitto_passwd/mosquitto_passwd.c
+++ b/apps/mosquitto_passwd/mosquitto_passwd.c
@@ -433,6 +433,7 @@ int main(int argc, char *argv[])
 	bool batch_mode = false;
 	bool create_new = false;
 	bool delete_user = false;
+	bool use_stdout = false;
 	FILE *fptr, *ftmp;
 	char password[MAX_BUFFER_LEN];
 	int rc;
@@ -529,7 +530,11 @@ int main(int argc, char *argv[])
 				fprintf(stderr, "Error: -c argument given but password file or username missing.\n");
 				return 1;
 			}else{
-				password_file_tmp = argv[idx];
+				if (!strcmp(argv[idx], "-")){
+					use_stdout = true;
+				}else{
+					password_file_tmp = argv[idx];
+				}
 				username = argv[idx+1];
 			}
 		}
@@ -568,27 +573,29 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
+	if(!use_stdout){
 #ifdef WIN32
-	password_file = _fullpath(NULL, password_file_tmp, 0);
-	if(!password_file){
-		fprintf(stderr, "Error getting full path for password file.\n");
-		return 1;
-	}
-#else
-	password_file = realpath(password_file_tmp, NULL);
-	if(!password_file){
-		if(errno == ENOENT){
-			password_file = strdup(password_file_tmp);
-			if(!password_file){
-				fprintf(stderr, "Error: Out of memory.\n");
-				return 1;
-			}
-		}else{
-			fprintf(stderr, "Error reading password file: %s\n", strerror(errno));
+		password_file = _fullpath(NULL, password_file_tmp, 0);
+		if(!password_file){
+			fprintf(stderr, "Error getting full path for password file.\n");
 			return 1;
 		}
-	}
+#else
+		password_file = realpath(password_file_tmp, NULL);
+		if(!password_file){
+			if(errno == ENOENT){
+				password_file = strdup(password_file_tmp);
+				if(!password_file){
+					fprintf(stderr, "Error: Out of memory.\n");
+					return 1;
+				}
+			}else{
+				fprintf(stderr, "Error reading password file: %s\n", strerror(errno));
+				return 1;
+			}
+		}
 #endif
+	}
 
 	if(create_new){
 		if(batch_mode == false){
@@ -599,13 +606,17 @@ int main(int argc, char *argv[])
 			}
 			password_cmd = password;
 		}
-		fptr = fopen(password_file, "wt");
-		if(!fptr){
-			fprintf(stderr, "Error: Unable to open file %s for writing. %s.\n", password_file, strerror(errno));
+		if(use_stdout){
+			fptr = stdout;
+		}else{
+			fptr = fopen(password_file, "wt");
+			if(!fptr){
+				fprintf(stderr, "Error: Unable to open file %s for writing. %s.\n", password_file, strerror(errno));
+				free(password_file);
+				return 1;
+			}
 			free(password_file);
-			return 1;
 		}
-		free(password_file);
 		rc = output_new_password(fptr, username, password_cmd, iterations);
 		fclose(fptr);
 		return rc;


### PR DESCRIPTION
parse a dash '-' to output a password to stdout when using -c 'create new password file'

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
