### PR TITLE
Copy scope id when binding to IPv6 Link-Local address

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -673,6 +673,9 @@ static int net__bind_interface(struct mosquitto__listener *listener, struct addr
 						memcpy(&((struct sockaddr_in6 *)rp->ai_addr)->sin6_addr,
 								&((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr,
 								sizeof(struct in6_addr));
+
+						((struct sockaddr_in6 *)rp->ai_addr)->sin6_scope_id = ((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_scope_id;
+
 						freeifaddrs(ifaddr);
 						return MOSQ_ERR_SUCCESS;
 					}

--- a/test/broker/readme.txt
+++ b/test/broker/readme.txt
@@ -17,3 +17,5 @@ Numbering is as follows:
 10: Listener tests
 11: Persistence tests
 12: Property tests
+13: Malformed tests
+14: Dynamic security tests


### PR DESCRIPTION
Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----

Configuring a listener with bind_interface on an interface with an ipv6 link-local address causes Mosquitto to exit with "Error: invalid argument". This happens due to the the IPv6 scope ID not being copied to the returned addrinfo struct when resolving interfaces matching `bind_interface`.

This PR adds a commit that also copies the sin6_scope_id when a matching interface is found.

Fixes #2696 