### PR TITLE
config.mk: fix adns build with glibc >= 2.35

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -314,7 +314,6 @@ ifeq ($(WITH_EC),yes)
 endif
 
 ifeq ($(WITH_ADNS),yes)
-	BROKER_LDADD:=$(BROKER_LDADD) -lanl
 	BROKER_CPPFLAGS:=$(BROKER_CPPFLAGS) -DWITH_ADNS
 endif
 


### PR DESCRIPTION
libanl is not built since glibc 2.35 and https://github.com/bminor/glibc/commit/737e873b305d8a2d925a8e346b84910eae5a39b3 resulting in the following build failure:

```
/home/autobuild/autobuild/instance-15/output-1/host/lib/gcc/or1k-buildroot-linux-gnu/12.3.0/../../../../or1k-buildroot-linux-gnu/bin/ld: cannot find -lanl: No such file or directory
```

So do not hardcode `-lanl` in `config.mk` as anl is already added if needed in `src/CMakeLists.txt` since
https://github.com/eclipse/mosquitto/commit/8406c08124a6984053c95b41cceff87878278a32

Fixes:
 - http://autobuild.buildroot.org/results/700de2a96e61d922662439ecd465350e4586a1e3