### PR TITLE
Add Timezone data to dockerfile

### DIFF
--- a/docker/2.0-openssl/Dockerfile
+++ b/docker/2.0-openssl/Dockerfile
@@ -17,7 +17,8 @@ RUN set -x && \
         gnupg \
         linux-headers \
         openssl-dev \
-        util-linux-dev && \
+        util-linux-dev \
+        tzdata && \
     wget https://github.com/warmcat/libwebsockets/archive/v${LWS_VERSION}.tar.gz -O /tmp/lws.tar.gz && \
     echo "$LWS_SHA256  /tmp/lws.tar.gz" | sha256sum -c - && \
     mkdir -p /build/lws && \

--- a/docker/2.0/Dockerfile
+++ b/docker/2.0/Dockerfile
@@ -17,7 +17,8 @@ RUN set -x && \
         gnupg \
         libressl-dev \
         linux-headers \
-        util-linux-dev && \
+        util-linux-dev \
+        tzdata && \
     wget https://github.com/warmcat/libwebsockets/archive/v${LWS_VERSION}.tar.gz -O /tmp/lws.tar.gz && \
     echo "$LWS_SHA256  /tmp/lws.tar.gz" | sha256sum -c - && \
     mkdir -p /build/lws && \

--- a/docker/generic/Dockerfile
+++ b/docker/generic/Dockerfile
@@ -20,7 +20,8 @@ RUN set -x && \
         gnupg \
         linux-headers \
         openssl-dev \
-        util-linux-dev && \
+        util-linux-dev
+        tzdata && \
     wget https://github.com/warmcat/libwebsockets/archive/v${LWS_VERSION}.tar.gz -O /tmp/lws.tar.gz && \
     echo "$LWS_SHA256  /tmp/lws.tar.gz" | sha256sum -c - && \
     mkdir -p /build/lws && \

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -15,7 +15,8 @@ RUN set -x && \
         linux-headers \
         openssl-dev \
         sqlite-dev \
-        util-linux-dev && \
+        util-linux-dev \
+        tzdata && \
     mkdir -p /build/mosq && \
     tar --strip=1 -xf /tmp/mosq.tar.gz -C /build/mosq && \
     rm /tmp/mosq.tar.gz && \


### PR DESCRIPTION
Adding timezone data (tzdata) package to dockerfile to allow Mosquitto to use local time in logs instead of UTC time.

Very simple change. Another developer can copy the changes and pull/merge it themselves. 