### PR TITLE
Only write to socket pair in threaded mode

### DIFF
--- a/lib/packet_mosq.c
+++ b/lib/packet_mosq.c
@@ -191,7 +191,7 @@ int packet__queue(struct mosquitto *mosq, struct mosquitto__packet *packet)
 
 	/* Write a single byte to sockpairW (connected to sockpairR) to break out
 	 * of select() if in threaded mode. */
-	if(mosq->sockpairW != INVALID_SOCKET){
+	if(mosq->threaded == mosq_ts_self && mosq->sockpairW != INVALID_SOCKET){
 #ifndef WIN32
 		if(write(mosq->sockpairW, &sockpair_data, 1)){
 		}


### PR DESCRIPTION
Otherwise it is possible to write to the socket pair when there is no consumer resulting in the buffer growing indefinitely. This issue manifests itself when an external event loop is used together with mosquitto_loop_read/mosquitto_loop_write/mosquitto_loop_misc instead of using mosquitto_loop, mosquitto_loop_forever or threaded mode with mosquitto_loop_start/mosquitto_loop_stop

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [X] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [X] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [X] If you are contributing a new feature, is your work based off the develop branch?
- [X] If you are contributing a bugfix, is your work based off the fixes branch?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully run `make test` with your changes locally?

-----
