### PR TITLE
Fix for issue 3239. Added COMPAT_ prefix to pthread_ calls

### DIFF
--- a/lib/actions.c
+++ b/lib/actions.c
@@ -155,10 +155,10 @@ int mosquitto_publish_v5(struct mosquitto *mosq, int *mid, const char *topic, in
 		message->dup = false;
 		message->properties = properties_copy;
 
-		pthread_mutex_lock(&mosq->msgs_out.mutex);
+		COMPAT_pthread_mutex_lock(&mosq->msgs_out.mutex);
 		message->state = mosq_ms_invalid;
 		rc = message__queue(mosq, message, mosq_md_out);
-		pthread_mutex_unlock(&mosq->msgs_out.mutex);
+		COMPAT_pthread_mutex_unlock(&mosq->msgs_out.mutex);
 		return rc;
 	}
 }

--- a/lib/callbacks.c
+++ b/lib/callbacks.c
@@ -24,99 +24,99 @@ Contributors:
 
 void mosquitto_connect_callback_set(struct mosquitto *mosq, void (*on_connect)(struct mosquitto *, void *, int))
 {
-	pthread_mutex_lock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 	mosq->on_connect = on_connect;
-	pthread_mutex_unlock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 }
 
 void mosquitto_connect_with_flags_callback_set(struct mosquitto *mosq, void (*on_connect)(struct mosquitto *, void *, int, int))
 {
-	pthread_mutex_lock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 	mosq->on_connect_with_flags = on_connect;
-	pthread_mutex_unlock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 }
 
 void mosquitto_connect_v5_callback_set(struct mosquitto *mosq, void (*on_connect)(struct mosquitto *, void *, int, int, const mosquitto_property *))
 {
-	pthread_mutex_lock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 	mosq->on_connect_v5 = on_connect;
-	pthread_mutex_unlock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 }
 
 void mosquitto_disconnect_callback_set(struct mosquitto *mosq, void (*on_disconnect)(struct mosquitto *, void *, int))
 {
-	pthread_mutex_lock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 	mosq->on_disconnect = on_disconnect;
-	pthread_mutex_unlock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 }
 
 void mosquitto_disconnect_v5_callback_set(struct mosquitto *mosq, void (*on_disconnect)(struct mosquitto *, void *, int, const mosquitto_property *))
 {
-	pthread_mutex_lock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 	mosq->on_disconnect_v5 = on_disconnect;
-	pthread_mutex_unlock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 }
 
 void mosquitto_publish_callback_set(struct mosquitto *mosq, void (*on_publish)(struct mosquitto *, void *, int))
 {
-	pthread_mutex_lock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 	mosq->on_publish = on_publish;
-	pthread_mutex_unlock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 }
 
 void mosquitto_publish_v5_callback_set(struct mosquitto *mosq, void (*on_publish)(struct mosquitto *, void *, int, int, const mosquitto_property *props))
 {
-	pthread_mutex_lock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 	mosq->on_publish_v5 = on_publish;
-	pthread_mutex_unlock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 }
 
 void mosquitto_message_callback_set(struct mosquitto *mosq, void (*on_message)(struct mosquitto *, void *, const struct mosquitto_message *))
 {
-	pthread_mutex_lock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 	mosq->on_message = on_message;
-	pthread_mutex_unlock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 }
 
 void mosquitto_message_v5_callback_set(struct mosquitto *mosq, void (*on_message)(struct mosquitto *, void *, const struct mosquitto_message *, const mosquitto_property *props))
 {
-	pthread_mutex_lock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 	mosq->on_message_v5 = on_message;
-	pthread_mutex_unlock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 }
 
 void mosquitto_subscribe_callback_set(struct mosquitto *mosq, void (*on_subscribe)(struct mosquitto *, void *, int, int, const int *))
 {
-	pthread_mutex_lock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 	mosq->on_subscribe = on_subscribe;
-	pthread_mutex_unlock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 }
 
 void mosquitto_subscribe_v5_callback_set(struct mosquitto *mosq, void (*on_subscribe)(struct mosquitto *, void *, int, int, const int *, const mosquitto_property *props))
 {
-	pthread_mutex_lock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 	mosq->on_subscribe_v5 = on_subscribe;
-	pthread_mutex_unlock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 }
 
 void mosquitto_unsubscribe_callback_set(struct mosquitto *mosq, void (*on_unsubscribe)(struct mosquitto *, void *, int))
 {
-	pthread_mutex_lock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 	mosq->on_unsubscribe = on_unsubscribe;
-	pthread_mutex_unlock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 }
 
 void mosquitto_unsubscribe_v5_callback_set(struct mosquitto *mosq, void (*on_unsubscribe)(struct mosquitto *, void *, int, const mosquitto_property *props))
 {
-	pthread_mutex_lock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 	mosq->on_unsubscribe_v5 = on_unsubscribe;
-	pthread_mutex_unlock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 }
 
 void mosquitto_log_callback_set(struct mosquitto *mosq, void (*on_log)(struct mosquitto *, void *, int, const char *))
 {
-	pthread_mutex_lock(&mosq->log_callback_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->log_callback_mutex);
 	mosq->on_log = on_log;
-	pthread_mutex_unlock(&mosq->log_callback_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->log_callback_mutex);
 }
 

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -179,10 +179,10 @@ static int mosquitto__reconnect(struct mosquitto *mosq, bool blocking)
 		if(rc) return rc;
 	}
 
-	pthread_mutex_lock(&mosq->msgtime_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->msgtime_mutex);
 	mosq->last_msg_in = mosquitto_time();
 	mosq->next_msg_out = mosq->last_msg_in + mosq->keepalive;
-	pthread_mutex_unlock(&mosq->msgtime_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->msgtime_mutex);
 
 	mosq->ping_t = 0;
 
@@ -271,7 +271,7 @@ void do_client_disconnect(struct mosquitto *mosq, int reason_code, const mosquit
 	net__socket_close(mosq);
 
 	/* Free data and reset values */
-	pthread_mutex_lock(&mosq->out_packet_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->out_packet_mutex);
 	mosq->current_out_packet = mosq->out_packet;
 	if(mosq->out_packet){
 		mosq->out_packet = mosq->out_packet->next;
@@ -280,13 +280,13 @@ void do_client_disconnect(struct mosquitto *mosq, int reason_code, const mosquit
 		}
 		mosq->out_packet_count--;
 	}
-	pthread_mutex_unlock(&mosq->out_packet_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->out_packet_mutex);
 
-	pthread_mutex_lock(&mosq->msgtime_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->msgtime_mutex);
 	mosq->next_msg_out = mosquitto_time() + mosq->keepalive;
-	pthread_mutex_unlock(&mosq->msgtime_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->msgtime_mutex);
 
-	pthread_mutex_lock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 	if(mosq->on_disconnect){
 		mosq->in_callback = true;
 		mosq->on_disconnect(mosq, mosq->userdata, reason_code);
@@ -297,7 +297,7 @@ void do_client_disconnect(struct mosquitto *mosq, int reason_code, const mosquit
 		mosq->on_disconnect_v5(mosq, mosq->userdata, reason_code, properties);
 		mosq->in_callback = false;
 	}
-	pthread_mutex_unlock(&mosq->callback_mutex);
-	pthread_mutex_unlock(&mosq->current_out_packet_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->current_out_packet_mutex);
 }
 

--- a/lib/handle_connack.c
+++ b/lib/handle_connack.c
@@ -36,7 +36,7 @@ static void connack_callback(struct mosquitto *mosq, uint8_t reason_code, uint8_
 	if(reason_code == MQTT_RC_SUCCESS){
 		mosq->reconnects = 0;
 	}
-	pthread_mutex_lock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 	if(mosq->on_connect){
 		mosq->in_callback = true;
 		mosq->on_connect(mosq, mosq->userdata, reason_code);
@@ -52,7 +52,7 @@ static void connack_callback(struct mosquitto *mosq, uint8_t reason_code, uint8_
 		mosq->on_connect_v5(mosq, mosq->userdata, reason_code, connect_flags, properties);
 		mosq->in_callback = false;
 	}
-	pthread_mutex_unlock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 }
 
 
@@ -117,11 +117,11 @@ int handle__connack(struct mosquitto *mosq)
 
 	switch(reason_code){
 		case 0:
-			pthread_mutex_lock(&mosq->state_mutex);
+			COMPAT_pthread_mutex_lock(&mosq->state_mutex);
 			if(mosq->state != mosq_cs_disconnecting){
 				mosq->state = mosq_cs_active;
 			}
-			pthread_mutex_unlock(&mosq->state_mutex);
+			COMPAT_pthread_mutex_unlock(&mosq->state_mutex);
 			message__retry_check(mosq);
 			return MOSQ_ERR_SUCCESS;
 		case 1:

--- a/lib/handle_pubackcomp.c
+++ b/lib/handle_pubackcomp.c
@@ -137,7 +137,7 @@ int handle__pubackcomp(struct mosquitto *mosq, const char *type)
 	rc = message__delete(mosq, mid, mosq_md_out, qos);
 	if(rc == MOSQ_ERR_SUCCESS){
 		/* Only inform the client the message has been sent once. */
-		pthread_mutex_lock(&mosq->callback_mutex);
+		COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 		if(mosq->on_publish){
 			mosq->in_callback = true;
 			mosq->on_publish(mosq, mosq->userdata, mid);
@@ -148,14 +148,14 @@ int handle__pubackcomp(struct mosquitto *mosq, const char *type)
 			mosq->on_publish_v5(mosq, mosq->userdata, mid, reason_code, properties);
 			mosq->in_callback = false;
 		}
-		pthread_mutex_unlock(&mosq->callback_mutex);
+		COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 		mosquitto_property_free_all(&properties);
 	}else if(rc != MOSQ_ERR_NOT_FOUND){
 		return rc;
 	}
-	pthread_mutex_lock(&mosq->msgs_out.mutex);
+	COMPAT_pthread_mutex_lock(&mosq->msgs_out.mutex);
 	message__release_to_inflight(mosq, mosq_md_out);
-	pthread_mutex_unlock(&mosq->msgs_out.mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->msgs_out.mutex);
 
 	return MOSQ_ERR_SUCCESS;
 #endif

--- a/lib/handle_publish.c
+++ b/lib/handle_publish.c
@@ -122,7 +122,7 @@ int handle__publish(struct mosquitto *mosq)
 	message->timestamp = mosquitto_time();
 	switch(message->msg.qos){
 		case 0:
-			pthread_mutex_lock(&mosq->callback_mutex);
+			COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 			if(mosq->on_message){
 				mosq->in_callback = true;
 				mosq->on_message(mosq, mosq->userdata, &message->msg);
@@ -133,14 +133,14 @@ int handle__publish(struct mosquitto *mosq)
 				mosq->on_message_v5(mosq, mosq->userdata, &message->msg, properties);
 				mosq->in_callback = false;
 			}
-			pthread_mutex_unlock(&mosq->callback_mutex);
+			COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 			message__cleanup(&message);
 			mosquitto_property_free_all(&properties);
 			return MOSQ_ERR_SUCCESS;
 		case 1:
 			util__decrement_receive_quota(mosq);
 			rc = send__puback(mosq, mid, 0, NULL);
-			pthread_mutex_lock(&mosq->callback_mutex);
+			COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 			if(mosq->on_message){
 				mosq->in_callback = true;
 				mosq->on_message(mosq, mosq->userdata, &message->msg);
@@ -151,7 +151,7 @@ int handle__publish(struct mosquitto *mosq)
 				mosq->on_message_v5(mosq, mosq->userdata, &message->msg, properties);
 				mosq->in_callback = false;
 			}
-			pthread_mutex_unlock(&mosq->callback_mutex);
+			COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 			message__cleanup(&message);
 			mosquitto_property_free_all(&properties);
 			return rc;
@@ -159,10 +159,10 @@ int handle__publish(struct mosquitto *mosq)
 			message->properties = properties;
 			util__decrement_receive_quota(mosq);
 			rc = send__pubrec(mosq, mid, 0, NULL);
-			pthread_mutex_lock(&mosq->msgs_in.mutex);
+			COMPAT_pthread_mutex_lock(&mosq->msgs_in.mutex);
 			message->state = mosq_ms_wait_for_pubrel;
 			message__queue(mosq, message, mosq_md_in);
-			pthread_mutex_unlock(&mosq->msgs_in.mutex);
+			COMPAT_pthread_mutex_unlock(&mosq->msgs_in.mutex);
 			return rc;
 		default:
 			message__cleanup(&message);

--- a/lib/handle_pubrec.c
+++ b/lib/handle_pubrec.c
@@ -107,18 +107,18 @@ int handle__pubrec(struct mosquitto *mosq)
 	}else{
 		if(!message__delete(mosq, mid, mosq_md_out, 2)){
 			/* Only inform the client the message has been sent once. */
-			pthread_mutex_lock(&mosq->callback_mutex);
+			COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 			if(mosq->on_publish_v5){
 				mosq->in_callback = true;
 				mosq->on_publish_v5(mosq, mosq->userdata, mid, reason_code, properties);
 				mosq->in_callback = false;
 			}
-			pthread_mutex_unlock(&mosq->callback_mutex);
+			COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 		}
 		util__increment_send_quota(mosq);
-		pthread_mutex_lock(&mosq->msgs_out.mutex);
+		COMPAT_pthread_mutex_lock(&mosq->msgs_out.mutex);
 		message__release_to_inflight(mosq, mosq_md_out);
-		pthread_mutex_unlock(&mosq->msgs_out.mutex);
+		COMPAT_pthread_mutex_unlock(&mosq->msgs_out.mutex);
 		return MOSQ_ERR_SUCCESS;
 	}
 #endif

--- a/lib/handle_pubrel.c
+++ b/lib/handle_pubrel.c
@@ -116,7 +116,7 @@ int handle__pubrel(struct mosquitto *mosq)
 	if(rc == MOSQ_ERR_SUCCESS){
 		/* Only pass the message on if we have removed it from the queue - this
 		 * prevents multiple callbacks for the same message. */
-		pthread_mutex_lock(&mosq->callback_mutex);
+		COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 		if(mosq->on_message){
 			mosq->in_callback = true;
 			mosq->on_message(mosq, mosq->userdata, &message->msg);
@@ -127,7 +127,7 @@ int handle__pubrel(struct mosquitto *mosq)
 			mosq->on_message_v5(mosq, mosq->userdata, &message->msg, message->properties);
 			mosq->in_callback = false;
 		}
-		pthread_mutex_unlock(&mosq->callback_mutex);
+		COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 		mosquitto_property_free_all(&properties);
 		message__cleanup(&message);
 	}else if(rc == MOSQ_ERR_NOT_FOUND){

--- a/lib/handle_suback.c
+++ b/lib/handle_suback.c
@@ -97,7 +97,7 @@ int handle__suback(struct mosquitto *mosq)
 	/* Immediately free, we don't do anything with Reason String or User Property at the moment */
 	mosquitto_property_free_all(&properties);
 #else
-	pthread_mutex_lock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 	if(mosq->on_subscribe){
 		mosq->in_callback = true;
 		mosq->on_subscribe(mosq, mosq->userdata, mid, qos_count, granted_qos);
@@ -108,7 +108,7 @@ int handle__suback(struct mosquitto *mosq)
 		mosq->on_subscribe_v5(mosq, mosq->userdata, mid, qos_count, granted_qos, properties);
 		mosq->in_callback = false;
 	}
-	pthread_mutex_unlock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 	mosquitto_property_free_all(&properties);
 #endif
 	mosquitto__free(granted_qos);

--- a/lib/handle_unsuback.c
+++ b/lib/handle_unsuback.c
@@ -76,7 +76,7 @@ int handle__unsuback(struct mosquitto *mosq)
 	/* Immediately free, we don't do anything with Reason String or User Property at the moment */
 	mosquitto_property_free_all(&properties);
 #else
-	pthread_mutex_lock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 	if(mosq->on_unsubscribe){
 		mosq->in_callback = true;
 		mosq->on_unsubscribe(mosq, mosq->userdata, mid);
@@ -87,7 +87,7 @@ int handle__unsuback(struct mosquitto *mosq)
 		mosq->on_unsubscribe_v5(mosq, mosq->userdata, mid, properties);
 		mosq->in_callback = false;
 	}
-	pthread_mutex_unlock(&mosq->callback_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 	mosquitto_property_free_all(&properties);
 #endif
 

--- a/lib/logging_mosq.c
+++ b/lib/logging_mosq.c
@@ -37,12 +37,12 @@ int log__printf(struct mosquitto *mosq, unsigned int priority, const char *fmt, 
 	assert(mosq);
 	assert(fmt);
 
-	pthread_mutex_lock(&mosq->log_callback_mutex);
+	COMPAT_pthread_mutex_lock(&mosq->log_callback_mutex);
 	if(mosq->on_log){
 		len = strlen(fmt) + 500;
 		s = mosquitto__malloc(len*sizeof(char));
 		if(!s){
-			pthread_mutex_unlock(&mosq->log_callback_mutex);
+			COMPAT_pthread_mutex_unlock(&mosq->log_callback_mutex);
 			return MOSQ_ERR_NOMEM;
 		}
 
@@ -55,7 +55,7 @@ int log__printf(struct mosquitto *mosq, unsigned int priority, const char *fmt, 
 
 		mosquitto__free(s);
 	}
-	pthread_mutex_unlock(&mosq->log_callback_mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->log_callback_mutex);
 
 	return MOSQ_ERR_SUCCESS;
 }

--- a/lib/messages_mosq.c
+++ b/lib/messages_mosq.c
@@ -142,7 +142,7 @@ void message__reconnect_reset(struct mosquitto *mosq, bool update_quota_only)
 	struct mosquitto_message_all *message, *tmp;
 	assert(mosq);
 
-	pthread_mutex_lock(&mosq->msgs_in.mutex);
+	COMPAT_pthread_mutex_lock(&mosq->msgs_in.mutex);
 	mosq->msgs_in.inflight_quota = mosq->msgs_in.inflight_maximum;
 	mosq->msgs_in.queue_len = 0;
 	DL_FOREACH_SAFE(mosq->msgs_in.inflight, message, tmp){
@@ -157,10 +157,10 @@ void message__reconnect_reset(struct mosquitto *mosq, bool update_quota_only)
 			util__decrement_receive_quota(mosq);
 		}
 	}
-	pthread_mutex_unlock(&mosq->msgs_in.mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->msgs_in.mutex);
 
 
-	pthread_mutex_lock(&mosq->msgs_out.mutex);
+	COMPAT_pthread_mutex_lock(&mosq->msgs_out.mutex);
 	mosq->msgs_out.inflight_quota = mosq->msgs_out.inflight_maximum;
 	mosq->msgs_out.queue_len = 0;
 	DL_FOREACH_SAFE(mosq->msgs_out.inflight, message, tmp){
@@ -185,7 +185,7 @@ void message__reconnect_reset(struct mosquitto *mosq, bool update_quota_only)
 			message->state = mosq_ms_invalid;
 		}
 	}
-	pthread_mutex_unlock(&mosq->msgs_out.mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->msgs_out.mutex);
 }
 
 
@@ -228,12 +228,12 @@ int message__remove(struct mosquitto *mosq, uint16_t mid, enum mosquitto_msg_dir
 	assert(message);
 
 	if(dir == mosq_md_out){
-		pthread_mutex_lock(&mosq->msgs_out.mutex);
+		COMPAT_pthread_mutex_lock(&mosq->msgs_out.mutex);
 
 		DL_FOREACH_SAFE(mosq->msgs_out.inflight, cur, tmp){
 			if(found == false && cur->msg.mid == mid){
 				if(cur->msg.qos != qos){
-					pthread_mutex_unlock(&mosq->msgs_out.mutex);
+					COMPAT_pthread_mutex_unlock(&mosq->msgs_out.mutex);
 					return MOSQ_ERR_PROTOCOL;
 				}
 				DL_DELETE(mosq->msgs_out.inflight, cur);
@@ -244,18 +244,18 @@ int message__remove(struct mosquitto *mosq, uint16_t mid, enum mosquitto_msg_dir
 				break;
 			}
 		}
-		pthread_mutex_unlock(&mosq->msgs_out.mutex);
+		COMPAT_pthread_mutex_unlock(&mosq->msgs_out.mutex);
 		if(found){
 			return MOSQ_ERR_SUCCESS;
 		}else{
 			return MOSQ_ERR_NOT_FOUND;
 		}
 	}else{
-		pthread_mutex_lock(&mosq->msgs_in.mutex);
+		COMPAT_pthread_mutex_lock(&mosq->msgs_in.mutex);
 		DL_FOREACH_SAFE(mosq->msgs_in.inflight, cur, tmp){
 			if(cur->msg.mid == mid){
 				if(cur->msg.qos != qos){
-					pthread_mutex_unlock(&mosq->msgs_in.mutex);
+					COMPAT_pthread_mutex_unlock(&mosq->msgs_in.mutex);
 					return MOSQ_ERR_PROTOCOL;
 				}
 				DL_DELETE(mosq->msgs_in.inflight, cur);
@@ -266,7 +266,7 @@ int message__remove(struct mosquitto *mosq, uint16_t mid, enum mosquitto_msg_dir
 			}
 		}
 
-		pthread_mutex_unlock(&mosq->msgs_in.mutex);
+		COMPAT_pthread_mutex_unlock(&mosq->msgs_in.mutex);
 		if(found){
 			return MOSQ_ERR_SUCCESS;
 		}else{
@@ -282,7 +282,7 @@ void message__retry_check(struct mosquitto *mosq)
 	assert(mosq);
 
 #ifdef WITH_THREADING
-	pthread_mutex_lock(&mosq->msgs_out.mutex);
+	COMPAT_pthread_mutex_lock(&mosq->msgs_out.mutex);
 #endif
 
 	DL_FOREACH(mosq->msgs_out.inflight, msg){
@@ -309,7 +309,7 @@ void message__retry_check(struct mosquitto *mosq)
 		}
 	}
 #ifdef WITH_THREADING
-	pthread_mutex_unlock(&mosq->msgs_out.mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->msgs_out.mutex);
 #endif
 }
 
@@ -325,20 +325,20 @@ int message__out_update(struct mosquitto *mosq, uint16_t mid, enum mosquitto_msg
 	struct mosquitto_message_all *message, *tmp;
 	assert(mosq);
 
-	pthread_mutex_lock(&mosq->msgs_out.mutex);
+	COMPAT_pthread_mutex_lock(&mosq->msgs_out.mutex);
 	DL_FOREACH_SAFE(mosq->msgs_out.inflight, message, tmp){
 		if(message->msg.mid == mid){
 			if(message->msg.qos != qos){
-				pthread_mutex_unlock(&mosq->msgs_out.mutex);
+				COMPAT_pthread_mutex_unlock(&mosq->msgs_out.mutex);
 				return MOSQ_ERR_PROTOCOL;
 			}
 			message->state = state;
 			message->timestamp = mosquitto_time();
-			pthread_mutex_unlock(&mosq->msgs_out.mutex);
+			COMPAT_pthread_mutex_unlock(&mosq->msgs_out.mutex);
 			return MOSQ_ERR_SUCCESS;
 		}
 	}
-	pthread_mutex_unlock(&mosq->msgs_out.mutex);
+	COMPAT_pthread_mutex_unlock(&mosq->msgs_out.mutex);
 	return MOSQ_ERR_NOT_FOUND;
 }
 

--- a/lib/mosquitto.c
+++ b/lib/mosquitto.c
@@ -209,18 +209,18 @@ int mosquitto_reinitialise(struct mosquitto *mosq, const char *id, bool clean_st
 	mosq->tls_ocsp_required = false;
 #endif
 #ifdef WITH_THREADING
-	pthread_mutex_init(&mosq->callback_mutex, NULL);
-	pthread_mutex_init(&mosq->log_callback_mutex, NULL);
-	pthread_mutex_init(&mosq->state_mutex, NULL);
-	pthread_mutex_init(&mosq->out_packet_mutex, NULL);
-	pthread_mutex_init(&mosq->current_out_packet_mutex, NULL);
-	pthread_mutex_init(&mosq->msgtime_mutex, NULL);
-	pthread_mutex_init(&mosq->msgs_in.mutex, NULL);
-	pthread_mutex_init(&mosq->msgs_out.mutex, NULL);
-	pthread_mutex_init(&mosq->mid_mutex, NULL);
+	COMPAT_pthread_mutex_init(&mosq->callback_mutex, NULL);
+	COMPAT_pthread_mutex_init(&mosq->log_callback_mutex, NULL);
+	COMPAT_pthread_mutex_init(&mosq->state_mutex, NULL);
+	COMPAT_pthread_mutex_init(&mosq->out_packet_mutex, NULL);
+	COMPAT_pthread_mutex_init(&mosq->current_out_packet_mutex, NULL);
+	COMPAT_pthread_mutex_init(&mosq->msgtime_mutex, NULL);
+	COMPAT_pthread_mutex_init(&mosq->msgs_in.mutex, NULL);
+	COMPAT_pthread_mutex_init(&mosq->msgs_out.mutex, NULL);
+	COMPAT_pthread_mutex_init(&mosq->mid_mutex, NULL);
 	mosq->thread_id = pthread_self();
 #endif
-	/* This must be after pthread_mutex_init(), otherwise the log mutex may be
+	/* This must be after COMPAT_pthread_mutex_init(), otherwise the log mutex may be
 	 * used before being initialised. */
 	if(net__socketpair(&mosq->sockpairR, &mosq->sockpairW)){
 		log__printf(mosq, MOSQ_LOG_WARNING,
@@ -238,8 +238,8 @@ void mosquitto__destroy(struct mosquitto *mosq)
 #ifdef WITH_THREADING
 #  ifdef HAVE_PTHREAD_CANCEL
 	if(mosq->threaded == mosq_ts_self && !pthread_equal(mosq->thread_id, pthread_self())){
-		pthread_cancel(mosq->thread_id);
-		pthread_join(mosq->thread_id, NULL);
+		COMPAT_pthread_cancel(mosq->thread_id);
+		COMPAT_pthread_join(mosq->thread_id, NULL);
 		mosq->threaded = mosq_ts_none;
 	}
 #  endif
@@ -248,15 +248,15 @@ void mosquitto__destroy(struct mosquitto *mosq)
 		/* If mosq->id is not NULL then the client has already been initialised
 		 * and so the mutexes need destroying. If mosq->id is NULL, the mutexes
 		 * haven't been initialised. */
-		pthread_mutex_destroy(&mosq->callback_mutex);
-		pthread_mutex_destroy(&mosq->log_callback_mutex);
-		pthread_mutex_destroy(&mosq->state_mutex);
-		pthread_mutex_destroy(&mosq->out_packet_mutex);
-		pthread_mutex_destroy(&mosq->current_out_packet_mutex);
-		pthread_mutex_destroy(&mosq->msgtime_mutex);
-		pthread_mutex_destroy(&mosq->msgs_in.mutex);
-		pthread_mutex_destroy(&mosq->msgs_out.mutex);
-		pthread_mutex_destroy(&mosq->mid_mutex);
+		COMPAT_pthread_mutex_destroy(&mosq->callback_mutex);
+		COMPAT_pthread_mutex_destroy(&mosq->log_callback_mutex);
+		COMPAT_pthread_mutex_destroy(&mosq->state_mutex);
+		COMPAT_pthread_mutex_destroy(&mosq->out_packet_mutex);
+		COMPAT_pthread_mutex_destroy(&mosq->current_out_packet_mutex);
+		COMPAT_pthread_mutex_destroy(&mosq->msgtime_mutex);
+		COMPAT_pthread_mutex_destroy(&mosq->msgs_in.mutex);
+		COMPAT_pthread_mutex_destroy(&mosq->msgs_out.mutex);
+		COMPAT_pthread_mutex_destroy(&mosq->mid_mutex);
 	}
 #endif
 	if(mosq->sock != INVALID_SOCKET){

--- a/lib/pthread_compat.h
+++ b/lib/pthread_compat.h
@@ -10,7 +10,7 @@
 #  define COMPAT_pthread_testcancel() pthread_testcancel()
 
 #  define COMPAT_pthread_mutex_init(A, B) pthread_mutex_init((A), (B))
-#  define COMPAT_pthread_mutex_destroy(A) pthread_mutex_init((A))
+#  define COMPAT_pthread_mutex_destroy(A) pthread_mutex_destroy((A))
 #  define COMPAT_pthread_mutex_lock(A) pthread_mutex_lock((A))
 #  define COMPAT_pthread_mutex_unlock(A) pthread_mutex_unlock((A))
 #else

--- a/lib/srv_mosq.c
+++ b/lib/srv_mosq.c
@@ -49,7 +49,7 @@ static void srv_callback(void *arg, int status, int timeouts, unsigned char *abu
 	}else{
 		log__printf(mosq, MOSQ_LOG_ERR, "Error: SRV lookup failed (%d).", status);
 		/* FIXME - calling on_disconnect here isn't correct. */
-		pthread_mutex_lock(&mosq->callback_mutex);
+		COMPAT_pthread_mutex_lock(&mosq->callback_mutex);
 		if(mosq->on_disconnect){
 			mosq->in_callback = true;
 			mosq->on_disconnect(mosq, mosq->userdata, MOSQ_ERR_LOOKUP);
@@ -60,7 +60,7 @@ static void srv_callback(void *arg, int status, int timeouts, unsigned char *abu
 			mosq->on_disconnect_v5(mosq, mosq->userdata, MOSQ_ERR_LOOKUP, NULL);
 			mosq->in_callback = false;
 		}
-		pthread_mutex_unlock(&mosq->callback_mutex);
+		COMPAT_pthread_mutex_unlock(&mosq->callback_mutex);
 	}
 }
 #endif

--- a/lib/thread_mosq.c
+++ b/lib/thread_mosq.c
@@ -42,7 +42,7 @@ int mosquitto_loop_start(struct mosquitto *mosq)
 	if(!mosq || mosq->threaded != mosq_ts_none) return MOSQ_ERR_INVAL;
 
 	mosq->threaded = mosq_ts_self;
-	if(!pthread_create(&mosq->thread_id, NULL, mosquitto__thread_main, mosq)){
+	if(!COMPAT_pthread_create(&mosq->thread_id, NULL, mosquitto__thread_main, mosq)){
 #if defined(__linux__)
 		pthread_setname_np(mosq->thread_id, "mosquitto loop");
 #elif defined(__NetBSD__)
@@ -83,10 +83,11 @@ int mosquitto_loop_stop(struct mosquitto *mosq, bool force)
 
 #ifdef HAVE_PTHREAD_CANCEL
 	if(force){
-		pthread_cancel(mosq->thread_id);
+		COMPAT_pthread_cancel()
+(mosq->thread_id);
 	}
 #endif
-	pthread_join(mosq->thread_id, NULL);
+	COMPAT_pthread_join(mosq->thread_id, NULL);
 	mosq->thread_id = pthread_self();
 	mosq->threaded = mosq_ts_none;
 

--- a/lib/thread_mosq.c
+++ b/lib/thread_mosq.c
@@ -83,8 +83,7 @@ int mosquitto_loop_stop(struct mosquitto *mosq, bool force)
 
 #ifdef HAVE_PTHREAD_CANCEL
 	if(force){
-		COMPAT_pthread_cancel()
-(mosq->thread_id);
+		COMPAT_pthread_cancel(mosq->thread_id);
 	}
 #endif
 	COMPAT_pthread_join(mosq->thread_id, NULL);


### PR DESCRIPTION
In v2.020 pthread defines was renamed to "COMPAT_" and functions are not changed in all required places causing build failure.


Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
