### PR TITLE
Warn capath option is not supported for websockets

### DIFF
--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -1326,6 +1326,7 @@ log_timestamp_format %Y-%m-%dT%H:%M:%S
 							"openssl rehash &lt;path to capath&gt;" each time
 							you add/remove a certificate.
 						</para>
+						<para><option>capath</option> is not supported for websockets.</para>
 					</listitem>
 				</varlistentry>
 				<varlistentry>

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -359,6 +359,7 @@
 # containing the CA certificates. For capath to work correctly, the
 # certificate files must have ".crt" as the file ending and you must run
 # "openssl rehash <path to capath>" each time you add/remove a certificate.
+# capath is not supported for websockets.
 #cafile
 #capath
 

--- a/src/websockets.c
+++ b/src/websockets.c
@@ -698,7 +698,12 @@ void mosq_websockets_init(struct mosquitto__listener *listener, const struct mos
 	info.gid = -1;
 	info.uid = -1;
 #ifdef WITH_TLS
-	info.ssl_ca_filepath = listener->cafile;
+	if(listener->cafile){
+		info.ssl_ca_filepath = listener->cafile;
+	}
+	else if(listener->capath){
+		log__printf(NULL, MOSQ_LOG_WARNING, "Warning: CA path option is not supported for websockets");
+	}
 	info.ssl_cert_filepath = listener->certfile;
 	info.ssl_private_key_filepath = listener->keyfile;
 	info.ssl_cipher_list = listener->ciphers;


### PR DESCRIPTION
  libwebsockets doesn't provide a direct option to support `capath`, ie
  a directory that contains multiple certificates.
  ( https://github.com/warmcat/libwebsockets/issues/3276 )
  
  To avoid confusion, explicitly state that it's not supported for
  websockets in the doc for mosquitto.conf, and add a warning if option is
  provided while `capath` is not provided.

---

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [ ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
1