### PR TITLE
Added Android specific includes

### DIFF
--- a/apps/db_dump/db_dump.c
+++ b/apps/db_dump/db_dump.c
@@ -38,6 +38,10 @@ Contributors:
 
 #include "db_dump.h"
 
+#ifdef __ANDROID__
+#include <sys/endian.h>
+#endif
+
 struct client_data
 {
 	UT_hash_handle hh_id;


### PR DESCRIPTION
Building mosquitto for Android using NDK r25 is working fine. But, when updating to r27 the following error is raised: 

> [ 79%] Linking C executable mosquitto
[ 79%] Built target mosquitto
[ 80%] Building C object apps/db_dump/CMakeFiles/mosquitto_db_dump.dir/db_dump.c.o
/home/builder/devopsagent/_work/521/s/mosquitto/apps/db_dump/db_dump.c:480:16: error: call to undeclared function 'ntohl'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  480 |                 db_version = ntohl(i32temp);
      |                              ^
1 error generated.

Adding <sys/endian.h> when build target is Android, fixes the issue. 

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [X] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [X] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
