### PR TITLE
test: Pass proto_ver to do_test() functions that require it

### DIFF
--- a/test/broker/02-subpub-qos1-message-expiry-retain.py
+++ b/test/broker/02-subpub-qos1-message-expiry-retain.py
@@ -13,35 +13,35 @@
 
 from mosq_test_helper import *
 
-def do_test():
+def do_test(proto_ver):
     rc = 1
     keepalive = 60
-    connect_packet = mosq_test.gen_connect("subpub", keepalive=keepalive, proto_ver=5)
-    connack_packet = mosq_test.gen_connack(rc=0, proto_ver=5)
+    connect_packet = mosq_test.gen_connect("subpub", keepalive=keepalive, proto_ver=proto_ver)
+    connack_packet = mosq_test.gen_connack(rc=0, proto_ver=proto_ver)
 
     mid = 1
-    subscribe1_packet = mosq_test.gen_subscribe(mid, "subpub/expired", 1, proto_ver=5)
-    suback1_packet = mosq_test.gen_suback(mid, 1, proto_ver=5)
+    subscribe1_packet = mosq_test.gen_subscribe(mid, "subpub/expired", 1, proto_ver=proto_ver)
+    suback1_packet = mosq_test.gen_suback(mid, 1, proto_ver=proto_ver)
 
     mid = 2
-    subscribe2_packet = mosq_test.gen_subscribe(mid, "subpub/kept", 1, proto_ver=5)
-    suback2_packet = mosq_test.gen_suback(mid, 1, proto_ver=5)
+    subscribe2_packet = mosq_test.gen_subscribe(mid, "subpub/kept", 1, proto_ver=proto_ver)
+    suback2_packet = mosq_test.gen_suback(mid, 1, proto_ver=proto_ver)
 
-    helper_connect = mosq_test.gen_connect("helper", proto_ver=5)
-    helper_connack = mosq_test.gen_connack(rc=0, proto_ver=5)
+    helper_connect = mosq_test.gen_connect("helper", proto_ver=proto_ver)
+    helper_connack = mosq_test.gen_connack(rc=0, proto_ver=proto_ver)
 
     mid=1
     props = mqtt5_props.gen_uint32_prop(mqtt5_props.PROP_MESSAGE_EXPIRY_INTERVAL, 4)
-    publish1_packet = mosq_test.gen_publish("subpub/expired", mid=mid, qos=1, retain=True, payload="message1", proto_ver=5, properties=props)
-    puback1_packet = mosq_test.gen_puback(mid, proto_ver=5, reason_code=mqtt5_rc.MQTT_RC_NO_MATCHING_SUBSCRIBERS)
+    publish1_packet = mosq_test.gen_publish("subpub/expired", mid=mid, qos=1, retain=True, payload="message1", proto_ver=proto_ver, properties=props)
+    puback1_packet = mosq_test.gen_puback(mid, proto_ver=proto_ver, reason_code=mqtt5_rc.MQTT_RC_NO_MATCHING_SUBSCRIBERS)
 
     mid=2
-    publish2s_packet = mosq_test.gen_publish("subpub/kept", mid=mid, qos=1, retain=True, payload="message2", proto_ver=5)
-    puback2s_packet = mosq_test.gen_puback(mid, proto_ver=5, reason_code=mqtt5_rc.MQTT_RC_NO_MATCHING_SUBSCRIBERS)
+    publish2s_packet = mosq_test.gen_publish("subpub/kept", mid=mid, qos=1, retain=True, payload="message2", proto_ver=proto_ver)
+    puback2s_packet = mosq_test.gen_puback(mid, proto_ver=proto_ver, reason_code=mqtt5_rc.MQTT_RC_NO_MATCHING_SUBSCRIBERS)
 
     mid=1
-    publish2r_packet = mosq_test.gen_publish("subpub/kept", mid=mid, qos=1, retain=True, payload="message2", proto_ver=5)
-    puback2r_packet = mosq_test.gen_puback(mid, proto_ver=5, reason_code=mqtt5_rc.MQTT_RC_NO_MATCHING_SUBSCRIBERS)
+    publish2r_packet = mosq_test.gen_publish("subpub/kept", mid=mid, qos=1, retain=True, payload="message2", proto_ver=proto_ver)
+    puback2r_packet = mosq_test.gen_puback(mid, proto_ver=proto_ver, reason_code=mqtt5_rc.MQTT_RC_NO_MATCHING_SUBSCRIBERS)
 
 
     port = mosq_test.get_port()
@@ -87,5 +87,5 @@ def do_test():
             exit(rc)
 
 
-do_test()
+do_test(proto_ver=5)
 exit(0)

--- a/test/broker/02-subpub-qos1-message-expiry-will.py
+++ b/test/broker/02-subpub-qos1-message-expiry-will.py
@@ -11,26 +11,26 @@
 
 from mosq_test_helper import *
 
-def do_test():
+def do_test(proto_ver):
     rc = 1
     mid = 53
     keepalive = 60
     props = mqtt5_props.gen_uint32_prop(mqtt5_props.PROP_SESSION_EXPIRY_INTERVAL, 60)
-    connect_packet = mosq_test.gen_connect("subpub-qos0-test", keepalive=keepalive, proto_ver=5, clean_session=False, properties=props)
-    connack1_packet = mosq_test.gen_connack(rc=0, proto_ver=5)
-    connack2_packet = mosq_test.gen_connack(rc=0, proto_ver=5, flags=1)
+    connect_packet = mosq_test.gen_connect("subpub-qos0-test", keepalive=keepalive, proto_ver=proto_ver, clean_session=False, properties=props)
+    connack1_packet = mosq_test.gen_connack(rc=0, proto_ver=proto_ver)
+    connack2_packet = mosq_test.gen_connack(rc=0, proto_ver=proto_ver, flags=1)
 
-    subscribe_packet = mosq_test.gen_subscribe(mid, "subpub/qos1", 1, proto_ver=5)
-    suback_packet = mosq_test.gen_suback(mid, 1, proto_ver=5)
+    subscribe_packet = mosq_test.gen_subscribe(mid, "subpub/qos1", 1, proto_ver=proto_ver)
+    suback_packet = mosq_test.gen_suback(mid, 1, proto_ver=proto_ver)
 
 
     props = mqtt5_props.gen_uint32_prop(mqtt5_props.PROP_MESSAGE_EXPIRY_INTERVAL, 10)
-    helper_connect = mosq_test.gen_connect("helper", proto_ver=5, will_topic="subpub/qos1", will_qos=1, will_payload=b"message", will_properties=props, keepalive=2)
-    helper_connack = mosq_test.gen_connack(rc=0, proto_ver=5)
+    helper_connect = mosq_test.gen_connect("helper", proto_ver=proto_ver, will_topic="subpub/qos1", will_qos=1, will_payload=b"message", will_properties=props, keepalive=2)
+    helper_connack = mosq_test.gen_connack(rc=0, proto_ver=proto_ver)
 
     #mid=2
     props = mqtt5_props.gen_uint32_prop(mqtt5_props.PROP_MESSAGE_EXPIRY_INTERVAL, 10)
-    publish2s_packet = mosq_test.gen_publish("subpub/qos1", mid=mid, qos=1, payload="message2", proto_ver=5, properties=props)
+    publish2s_packet = mosq_test.gen_publish("subpub/qos1", mid=mid, qos=1, payload="message2", proto_ver=proto_ver, properties=props)
     puback2s_packet = mosq_test.gen_puback(mid)
 
 
@@ -50,7 +50,7 @@ def do_test():
         packet = sock.recv(len(publish2s_packet))
         for i in range(10, 5, -1):
             props = mqtt5_props.gen_uint32_prop(mqtt5_props.PROP_MESSAGE_EXPIRY_INTERVAL, i)
-            publish2r_packet = mosq_test.gen_publish("subpub/qos1", mid=1, qos=1, payload="message", proto_ver=5, properties=props)
+            publish2r_packet = mosq_test.gen_publish("subpub/qos1", mid=1, qos=1, payload="message", proto_ver=proto_ver, properties=props)
             if packet == publish2r_packet:
                 rc = 0
                 break
@@ -68,5 +68,5 @@ def do_test():
             exit(rc)
 
 
-do_test()
+do_test(proto_ver=5)
 exit(0)

--- a/test/broker/02-subpub-qos1-message-expiry.py
+++ b/test/broker/02-subpub-qos1-message-expiry.py
@@ -11,31 +11,31 @@
 
 from mosq_test_helper import *
 
-def do_test():
+def do_test(proto_ver):
     rc = 1
     mid = 53
     keepalive = 60
     props = mqtt5_props.gen_uint32_prop(mqtt5_props.PROP_SESSION_EXPIRY_INTERVAL, 60)
-    connect_packet = mosq_test.gen_connect("subpub-qos0-test", keepalive=keepalive, proto_ver=5, clean_session=False, properties=props)
-    connack1_packet = mosq_test.gen_connack(rc=0, proto_ver=5)
-    connack2_packet = mosq_test.gen_connack(rc=0, proto_ver=5, flags=1)
+    connect_packet = mosq_test.gen_connect("subpub-qos0-test", keepalive=keepalive, proto_ver=proto_ver, clean_session=False, properties=props)
+    connack1_packet = mosq_test.gen_connack(rc=0, proto_ver=proto_ver)
+    connack2_packet = mosq_test.gen_connack(rc=0, proto_ver=proto_ver, flags=1)
 
-    subscribe_packet = mosq_test.gen_subscribe(mid, "subpub/qos1", 1, proto_ver=5)
-    suback_packet = mosq_test.gen_suback(mid, 1, proto_ver=5)
+    subscribe_packet = mosq_test.gen_subscribe(mid, "subpub/qos1", 1, proto_ver=proto_ver)
+    suback_packet = mosq_test.gen_suback(mid, 1, proto_ver=proto_ver)
 
 
 
-    helper_connect = mosq_test.gen_connect("helper", proto_ver=5)
-    helper_connack = mosq_test.gen_connack(rc=0, proto_ver=5)
+    helper_connect = mosq_test.gen_connect("helper", proto_ver=proto_ver)
+    helper_connack = mosq_test.gen_connack(rc=0, proto_ver=proto_ver)
 
     mid=1
     props = mqtt5_props.gen_uint32_prop(mqtt5_props.PROP_MESSAGE_EXPIRY_INTERVAL, 1)
-    publish1s_packet = mosq_test.gen_publish("subpub/qos1", mid=mid, qos=1, payload="message1", proto_ver=5, properties=props)
+    publish1s_packet = mosq_test.gen_publish("subpub/qos1", mid=mid, qos=1, payload="message1", proto_ver=proto_ver, properties=props)
     puback1s_packet = mosq_test.gen_puback(mid)
 
     mid=2
     props = mqtt5_props.gen_uint32_prop(mqtt5_props.PROP_MESSAGE_EXPIRY_INTERVAL, 10)
-    publish2s_packet = mosq_test.gen_publish("subpub/qos1", mid=mid, qos=1, payload="message2", proto_ver=5, properties=props)
+    publish2s_packet = mosq_test.gen_publish("subpub/qos1", mid=mid, qos=1, payload="message2", proto_ver=proto_ver, properties=props)
     puback2s_packet = mosq_test.gen_puback(mid)
 
 
@@ -57,7 +57,7 @@ def do_test():
         packet = sock.recv(len(publish2s_packet))
         for i in range(9, 5, -1):
             props = mqtt5_props.gen_uint32_prop(mqtt5_props.PROP_MESSAGE_EXPIRY_INTERVAL, i)
-            publish2r_packet = mosq_test.gen_publish("subpub/qos1", mid=2, qos=1, payload="message2", proto_ver=5, properties=props)
+            publish2r_packet = mosq_test.gen_publish("subpub/qos1", mid=2, qos=1, payload="message2", proto_ver=proto_ver, properties=props)
             if packet == publish2r_packet:
                 rc = 0
                 break
@@ -75,5 +75,5 @@ def do_test():
             exit(rc)
 
 
-do_test()
+do_test(proto_ver=5)
 exit(0)

--- a/test/broker/02-subpub-qos2-pubrec-error.py
+++ b/test/broker/02-subpub-qos2-pubrec-error.py
@@ -30,25 +30,25 @@ def helper(port):
     sock.close()
 
 
-def do_test():
+def do_test(proto_ver):
     rc = 1
     keepalive = 60
-    connect_packet = mosq_test.gen_connect("pub-qo2-timeout-test", keepalive=keepalive, proto_ver=5)
-    connack_packet = mosq_test.gen_connack(rc=0, proto_ver=5)
+    connect_packet = mosq_test.gen_connect("pub-qo2-timeout-test", keepalive=keepalive, proto_ver=proto_ver)
+    connack_packet = mosq_test.gen_connack(rc=0, proto_ver=proto_ver)
 
     mid = 1
-    subscribe_packet = mosq_test.gen_subscribe(mid, "qos2/pubrec/+", 2, proto_ver=5)
-    suback_packet = mosq_test.gen_suback(mid, 2, proto_ver=5)
+    subscribe_packet = mosq_test.gen_subscribe(mid, "qos2/pubrec/+", 2, proto_ver=proto_ver)
+    suback_packet = mosq_test.gen_suback(mid, 2, proto_ver=proto_ver)
 
     mid = 1
-    publish_1_packet = mosq_test.gen_publish("qos2/pubrec/rejected", qos=2, mid=mid, payload="rejected-message", proto_ver=5)
-    pubrec_1_packet = mosq_test.gen_pubrec(mid, proto_ver=5, reason_code=0x80)
+    publish_1_packet = mosq_test.gen_publish("qos2/pubrec/rejected", qos=2, mid=mid, payload="rejected-message", proto_ver=proto_ver)
+    pubrec_1_packet = mosq_test.gen_pubrec(mid, proto_ver=proto_ver, reason_code=0x80)
 
     mid = 2
-    publish_2_packet = mosq_test.gen_publish("qos2/pubrec/accepted", qos=2, mid=mid, payload="accepted-message", proto_ver=5)
-    pubrec_2_packet = mosq_test.gen_pubrec(mid, proto_ver=5)
-    pubrel_2_packet = mosq_test.gen_pubrel(mid, proto_ver=5)
-    pubcomp_2_packet = mosq_test.gen_pubcomp(mid, proto_ver=5)
+    publish_2_packet = mosq_test.gen_publish("qos2/pubrec/accepted", qos=2, mid=mid, payload="accepted-message", proto_ver=proto_ver)
+    pubrec_2_packet = mosq_test.gen_pubrec(mid, proto_ver=proto_ver)
+    pubrel_2_packet = mosq_test.gen_pubrel(mid, proto_ver=proto_ver)
+    pubcomp_2_packet = mosq_test.gen_pubcomp(mid, proto_ver=proto_ver)
 
     port = mosq_test.get_port()
     broker = mosq_test.start_broker(filename=os.path.basename(__file__), port=port)
@@ -81,5 +81,5 @@ def do_test():
             exit(rc)
 
 
-do_test()
+do_test(proto_ver=5)
 exit(0)


### PR DESCRIPTION
These test scripts all contain a `finally:` block that attempts to print proto_ver which does not exist:

```
print("proto_ver=%d" % (proto_ver))
```

This mistake appears to be a copy-and-paste error in commit b2a9daf ("02 broker subpub tests with v5 support") and went unnoticed because the code is only reached if the tests fail.

Fixes: b2a9daf1 ("02 broker subpub tests with v5 support")
Closes: https://github.com/eclipse-mosquitto/mosquitto/issues/3123