### PR TITLE
fix: compile failed when WITH_TLS is off

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -2313,6 +2313,7 @@ static int config__check(struct mosquitto__config *config)
 		}
 	}
 
+#ifdef WITH_TLS
 	/* Check for missing TLS cafile/capath/certfile/keyfile */
 	for(int i=0; i<config->listener_count; i++){
 		 bool cafile = !!config->listeners[i].cafile;
@@ -2333,6 +2334,7 @@ static int config__check(struct mosquitto__config *config)
 			 return MOSQ_ERR_INVAL;
 		 }
 	}
+#endif
 	return MOSQ_ERR_SUCCESS;
 }
 


### PR DESCRIPTION
when WITH_TLS is off, errors such as

mosquitto/src/conf.c:2318:54: error: ‘struct mosquitto__listener’ has no member named ‘cafile’
 2318 |                  bool cafile = !!config->listeners[i].cafile;

may occur during the compilation process