### PR TITLE
Fix return MOSQ_ERR_MALFORMED_PACKET when suback reserved bit not empty

### DIFF
--- a/lib/handle_suback.c
+++ b/lib/handle_suback.c
@@ -50,7 +50,7 @@ int handle__suback(struct mosquitto *mosq)
 	if(mosquitto__get_state(mosq) != mosq_cs_active){
 		return MOSQ_ERR_PROTOCOL;
 	}
-	if(mosq->in_packet.command != CMD_SUBACK){
+	if((mosq->in_packet.command >> 4) != (CMD_SUBACK >> 4)){
 		return MOSQ_ERR_MALFORMED_PACKET;
 	}
 


### PR DESCRIPTION
Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [ ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
