### PR TITLE
Report IP address in disconnection error messages

### DIFF
--- a/src/loop.c
+++ b/src/loop.c
@@ -320,7 +320,7 @@ void do_disconnect(struct mosquitto *context, int reason)
 			if(context->id){
 				id = context->id;
 			}else{
-				id = "<unknown>";
+				id = context->address;
 			}
 			if(context->state != mosq_cs_disconnecting && context->state != mosq_cs_disconnect_with_will){
 				switch(reason){


### PR DESCRIPTION
This enables tools like fail2ban to work.

Reference: https://github.com/fail2ban/fail2ban/issues/3427#issuecomment-1339686038
Closes: https://github.com/eclipse-mosquitto/mosquitto/issues/2076

cc: @ralight 