### PR TITLE
src/conf.c: don't check for missing tls files when not using it

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -2313,6 +2313,7 @@ static int config__check(struct mosquitto__config *config)
 		}
 	}
 
+#ifdef WITH_TLS
 	/* Check for missing TLS cafile/capath/certfile/keyfile */
 	for(int i=0; i<config->listener_count; i++){
 		 bool cafile = !!config->listeners[i].cafile;
@@ -2333,6 +2334,7 @@ static int config__check(struct mosquitto__config *config)
 			 return MOSQ_ERR_INVAL;
 		 }
 	}
+#endif
 	return MOSQ_ERR_SUCCESS;
 }
 


### PR DESCRIPTION
This fixes the WITH_TLS=no compilation.

conf.c: In function ‘config__check’:
conf.c:2319:53: error: ‘struct mosquitto__listener’ has no member named      \
‘cafile’
 2319 |                 bool cafile = !!config->listeners[i].cafile;
      |                                                     ^
conf.c:2320:53: error: ‘struct mosquitto__listener’ has no member named      \
‘capath’
 2320 |                 bool capath = !!config->listeners[i].capath;
      |                                                     ^
conf.c:2321:55: error: ‘struct mosquitto__listener’ has no member named      \
‘certfile’
 2321 |                 bool certfile = !!config->listeners[i].certfile;
      |                                                       ^
conf.c:2322:54: error: ‘struct mosquitto__listener’ has no member named      \
‘keyfile’
 2322 |                 bool keyfile = !!config->listeners[i].keyfile;
      |                                                      ^
make[1]: *** [Makefile:100: conf.o] Error 1
make[1]: Leaving directory 'xxx/mosquitto/src'
make: *** [Makefile:66: mosquitto] Error 2

-----
