### PR TITLE
Fix config.h to avoid conflicting _POSIX_C_SOURCE

### DIFF
--- a/config.h
+++ b/config.h
@@ -15,7 +15,6 @@
 #else
 #  define _XOPEN_SOURCE 700
 #  define _DEFAULT_SOURCE 1
-#  define _POSIX_C_SOURCE 200809L
 #endif
 
 


### PR DESCRIPTION
When _DEFAULT_SOURCE is defined, it is unnecessary to define _POSIX_C_SOURCE explicitly,  as libc implicitly sets it (typically to 200809L). Explicitly defining _POSIX_C_SOURCE  can lead to compatibility issues on systems where libc does not default to 200809L

This change avoids redundant or conflicting macro definitions for better portability.

You can read more details here https://man7.org/linux/man-pages/man7/feature_test_macros.7.html