### PR TITLE
[3049] Do not expire session if item is a bridge

### DIFF
--- a/src/session_expiry.c
+++ b/src/session_expiry.c
@@ -154,7 +154,8 @@ void session_expiry__check(void)
 	last_check = db.now_real_s;
 
 	DL_FOREACH_SAFE(expiry_list, item, tmp){
-		if(item->context->session_expiry_time < db.now_real_s){
+		/* Do not expire if it is a bridge. */
+		if(item->context->session_expiry_time < db.now_real_s && !item->context->bridge ){
 
 			context = item->context;
 			session_expiry__remove(context);
@@ -172,6 +173,10 @@ void session_expiry__check(void)
 			context__send_will(context);
 			context__add_to_disused(context);
 		}else{
+			if (item->context->bridge) {
+                            mosquitto_log_printf(MOSQ_LOG_NOTICE, "Skipping expiry for bridge %s", item->context->id);
+                            continue;
+                        }
 			return;
 		}
 	}


### PR DESCRIPTION
When persistence true and upgrading mosquitto library from version<= 2.0.15 to version>= 2.0.16, all the clients and the bridge are expired by timeout.

Avoid expiring the bridge by checking the item context.

Bug: https://github.com/eclipse-mosquitto/mosquitto/issues/3049

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run make test with your changes locally?
