### PR TITLE
Web-based dashboard headless mode and copy-to-clipboard fallback 

### DIFF
--- a/dashboard/src/listeners.html
+++ b/dashboard/src/listeners.html
@@ -120,8 +120,11 @@
        </div>
    </div>
     <script src="consts.js"></script>
+    <script src="queue.js"></script>
+    <script src="assert.js"></script>
     <script src="utils.js"></script>
     <script src="sidebar.js"></script>
+    <script src="dashboard.js"></script>
     <script src="listeners.js"></script>
 </body>
 </html>

--- a/dashboard/src/listeners.js
+++ b/dashboard/src/listeners.js
@@ -145,7 +145,7 @@ class Listeners {
     copyButton.addEventListener("click", async () => {
       try {
         const command = this.generateConnectionCommand(listener, type);
-        await navigator.clipboard.writeText(command);
+        copyToClipboard(command);
 
         copyIcon.style.display = "none";
         checkIcon.style.display = "block";
@@ -157,8 +157,7 @@ class Listeners {
           copyButton.title = "Copy command";
         }, 2000);
       } catch (err) {
-        console.error("Error when copying:", err);
-        // TODO: add some fallback for old browsers here
+        console.error("Error when copying to clipboard:", err);
       }
     });
 
@@ -284,4 +283,5 @@ class Listeners {
 document.addEventListener("DOMContentLoaded", () => {
   new Sidebar();
   new Listeners();
+  new MosquittoDashboard(true);
 });

--- a/dashboard/src/utils.js
+++ b/dashboard/src/utils.js
@@ -140,3 +140,24 @@ function secondsToIntervalString(number) {
 
   return intervalString;
 }
+
+async function copyToClipboard(textToCopy) {
+  if (navigator.clipboard) {
+    return await navigator.clipboard.writeText(textToCopy);
+  }
+
+  const dummyTextArea = document.createElement("textarea");
+  dummyTextArea.value = textToCopy;
+
+  document.body.appendChild(dummyTextArea);
+  dummyTextArea.focus({ preventScroll: true });
+  dummyTextArea.select();
+
+  try {
+    document.execCommand("copy");
+  } catch (err) {
+    throw new Error("Copy command failed: " + err?.message);
+  } finally {
+    dummyTextArea.remove();
+  }
+}


### PR DESCRIPTION
This PR adds additional enhancements to the web-based dashboard. It adds a so-called "headless" mode, which enables the dashboard (the index.html webpage with system metrics charts) to still receive data in the background, while users are on other pages. The solution is to inject the dashboard in this headless mode into other web pages.
In addition, this PR also adds a fallback for the "copy to clipboard" functionality to support older browsers. This functionality is relevant when copying "mosquitto_pub" commands in on the listeners page.

(Serhii Orlivskyi, Cedalo GmbH)


Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
