### PR TITLE
fix: typos

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -353,7 +353,7 @@ Broker:
   These clients are now rejected if their keepalive value exceeds
   max_keepalive. This option allows CVE-2020-13849, which is for the MQTT
   v3.1.1 protocol itself rather than an implementation, to be addressed.
-- Fix broker not quiting if e.g. the `password_file` is specified as a
+- Fix broker not quitting if e.g. the `password_file` is specified as a
   directory. Closes #2241.
 - Fix listener mount_point not being removed on outgoing messages.
   Closes #2244.
@@ -469,7 +469,7 @@ Broker:
 - Fix encrypted bridge connections incorrectly connecting when `bridge_cafile`
   is empty or invalid. Closes #2130.
 - Fix `tls_version` behaviour not matching documentation. It was setting the
-  exact TLS version to use, not the minimium TLS version to use. Closes #2110.
+  exact TLS version to use, not the minimum TLS version to use. Closes #2110.
 - Fix messages to `$` prefixed topics being rejected. Closes #2111.
 - Fix QoS 0 messages not being delivered when max_queued_bytes was configured.
   Closes #2123.
@@ -863,7 +863,7 @@ Client library features:
   trust OS provided CA certificates for use with TLS connections.
 
 Client library fixes:
-- Fix send quota being incorrecly reset on reconnect. Closes #1822.
+- Fix send quota being incorrectly reset on reconnect. Closes #1822.
 - Don't use logging until log mutex is initialised. Closes #1819.
 - Fix missing mach/mach_time.h header on OS X. Closes #1831.
 - Fix connect properties not being sent when the client automatically
@@ -1086,7 +1086,7 @@ Clients:
   end with a new line. Closes #1473.
 - Make documentation for `mosquitto_pub -l` match reality - blank lines are
   sent as empty messages. Closes #1474.
-- Free memory in `mosquitto_sub` when quiting without having made a successful
+- Free memory in `mosquitto_sub` when quitting without having made a successful
   connection. Closes #1513.
 
 Build:
@@ -1891,7 +1891,7 @@ Broker:
 - Fix mosquitto.db from becoming corrupted due to client messages being
   persisted with no stored message. Closes #424.
 - Fix bridge not restarting properly. Closes #428.
-- Fix unitialized memory in gets_quiet on Windows. Closes #426.
+- Fix uninitialized memory in gets_quiet on Windows. Closes #426.
 - Fix building with WITH_ADNS=no for systems that don't use glibc. Closes
   #415.
 - Fixes to readme.md.
@@ -2066,7 +2066,7 @@ Broker:
 Broker:
 - Fix incorrect bridge notification on initial connection. Closes #467096.
 - Build fixes for OpenBSD.
-- Fix incorrect behaviour for autosave_interval, most noticable for
+- Fix incorrect behaviour for autosave_interval, most noticeable for
   autosave_interval=1. Closes #465438.
 - Fix handling of outgoing QoS>0 messages for bridges that could not be sent
   because the bridge connection was down.
@@ -2515,7 +2515,7 @@ Client library:
 - Add support for verifying remote server certificate subject against the
   remote hostname.
 - Add mosquitto_reconnect_async() support and make asynchronous connections
-  truely asynchronous rather than simply deferred. DNS lookups are still
+  truly asynchronous rather than simply deferred. DNS lookups are still
   blocking, so asynchronous connections require an IP address instead of
   hostname.
 - Allow control of reconnection timeouts in mosquitto_loop_forever() and after
@@ -2912,7 +2912,7 @@ Other:
 0.14.1 - 20111117
 =================
 
-- Fix Python sytax errors (bug #891673).
+- Fix Python syntax errors (bug #891673).
 
 0.14 - 20111116
 ===============

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ your config file then run as `mosquitto -c /path/to/mosquitto.conf`.
 
 To start your config file you define a listener and you will need to think
 about what authentication you require. It is not advised to run your broker
-with anonymous access when it is publically available.
+with anonymous access when it is publicly available.
 
 For details on how to do this, look at the
 [authentication methods](https://mosquitto.org/documentation/authentication-methods/)

--- a/config.mk
+++ b/config.mk
@@ -9,7 +9,7 @@
 #
 # Modify the variable below to enable/disable features.
 #
-# Can also be overriden at the command line, e.g.:
+# Can also be overridden at the command line, e.g.:
 #
 # make WITH_TLS=no
 # =============================================================================

--- a/include/mosquitto.h
+++ b/include/mosquitto.h
@@ -1691,7 +1691,7 @@ libmosq_EXPORT int mosquitto_reconnect_delay_set(struct mosquitto *mosq, unsigne
 /*
  * Function: mosquitto_max_inflight_messages_set
  *
- * This function is deprected. Use the <mosquitto_int_option> function with the
+ * This function is deprecated. Use the <mosquitto_int_option> function with the
  * MOSQ_OPT_SEND_MAXIMUM option instead.
  *
  * Set the number of QoS 1 and 2 messages that can be "in flight" at one time.

--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -148,7 +148,7 @@
 						keyword.</para>
 					<para><code>pattern [read|write|readwrite|deny] &lt;topic&gt;</code></para>
 
-					<para>The patterns available for substition are:</para>
+					<para>The patterns available for substitution are:</para>
 					<itemizedlist mark="circle">
 						<listitem><para>%c to match the client id of the client</para></listitem>
 						<listitem><para>%u to match the username of the client</para></listitem>
@@ -1546,7 +1546,7 @@ openssl dhparam -out dhparam.pem 2048</programlisting>
 							be chosen from the list of available PSK ciphers.
 							If you want to control which ciphers are available,
 							use this option.  The list of available ciphers can
-							be optained using the "openssl ciphers" command and
+							be obtained using the "openssl ciphers" command and
 							should be provided in the same format as the output
 							of that command.</para>
 					</listitem>

--- a/man/mosquitto_ctrl.1.xml
+++ b/man/mosquitto_ctrl.1.xml
@@ -496,7 +496,7 @@
 				<term><option>--protocol-version</option></term>
 				<listitem>
 					<para>Specify which version of the MQTT protocol should be
-						used when connecting to the rmeote broker. Can be
+						used when connecting to the remote broker. Can be
 						<option>5</option>, <option>311</option>,
 						<option>31</option>, or the more verbose
 						<option>mqttv5</option>, <option>mqttv311</option>, or

--- a/man/mosquitto_pub.1.xml
+++ b/man/mosquitto_pub.1.xml
@@ -604,7 +604,7 @@
 				<term><option>--protocol-version</option></term>
 				<listitem>
 					<para>Specify which version of the MQTT protocol should be
-						used when connecting to the rmeote broker. Can be
+						used when connecting to the remote broker. Can be
 						<option>5</option>, <option>311</option>,
 						<option>31</option>, or the more verbose
 						<option>mqttv5</option>, <option>mqttv311</option>, or

--- a/man/mosquitto_rr.1.xml
+++ b/man/mosquitto_rr.1.xml
@@ -631,7 +631,7 @@
 				<term><option>--protocol-version</option></term>
 				<listitem>
 					<para>Specify which version of the MQTT protocol should be
-						used when connecting to the rmeote broker. Can be
+						used when connecting to the remote broker. Can be
 						<option>5</option>, <option>311</option>,
 						<option>31</option>, or the more verbose
 						<option>mqttv5</option>, <option>mqttv311</option>, or

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -321,7 +321,7 @@
 #keyfile
 
 # If you wish to control which encryption ciphers are used, use the ciphers
-# option. The list of available ciphers can be optained using the "openssl
+# option. The list of available ciphers can be obtained using the "openssl
 # ciphers" command and should be provided in the same format as the output of
 # that command. This applies to TLS 1.2 and earlier versions only. Use
 # ciphers_tls1.3 for TLS v1.3.
@@ -390,7 +390,7 @@
 
 # When using PSK, the encryption ciphers used will be chosen from the list of
 # available PSK ciphers. If you want to control which ciphers are available,
-# use the "ciphers" option.  The list of available ciphers can be optained
+# use the "ciphers" option.  The list of available ciphers can be obtained
 # using the "openssl ciphers" command and should be provided in the same format
 # as the output of that command.
 #ciphers
@@ -572,7 +572,7 @@
 # not given then the access is read/write.  <topic> can contain the + or #
 # wildcards as in subscriptions.
 #
-# The "deny" option can used to explicity deny access to a topic that would
+# The "deny" option can used to explicitly deny access to a topic that would
 # otherwise be granted by a broader read/write/readwrite statement. Any "deny"
 # topics are handled before topics that grant read/write access.
 #
@@ -587,7 +587,7 @@
 #
 #
 # If is also possible to define ACLs based on pattern substitution within the
-# topic. The patterns available for substition are:
+# topic. The patterns available for substitution are:
 #
 # %c to match the client id of the client
 # %u to match the username of the client

--- a/src/handle_connect.c
+++ b/src/handle_connect.c
@@ -550,7 +550,7 @@ int handle__connect(struct mosquitto *context)
 	}
 
 	clean_start = (connect_flags & 0x02) >> 1;
-	/* session_expiry_interval will be overriden if the properties are read later */
+	/* session_expiry_interval will be overridden if the properties are read later */
 	if(clean_start == false && protocol_version != PROTOCOL_VERSION_v5){
 		/* v3* has clean_start == false mean the session never expires */
 		context->session_expiry_interval = UINT32_MAX;

--- a/www/conf.py
+++ b/www/conf.py
@@ -1154,7 +1154,7 @@ PRETTY_URLS = True
 # feature yet, it's faster and the output looks better.
 # USE_KATEX = False
 
-# KaTeX auto-render settings. If you want support for the $.$ syntax (wihch may
+# KaTeX auto-render settings. If you want support for the $.$ syntax (which may
 # conflict with running text!), just use this config:
 # KATEX_AUTO_RENDER = """
 # delimiters: [
@@ -1253,7 +1253,7 @@ COPY_SOURCES = False
 
 # Include preview image as a <figure><img></figure> at the top of the entry.
 # Requires FEED_PLAIN = False. If the preview image is found in the content,
-# it will not be included again. Image will be included as-is, aim to optmize
+# it will not be included again. Image will be included as-is, aim to optimize
 # the image source for Feedly, Apple News, Flipboard, and other popular clients.
 # FEED_PREVIEWIMAGE = True
 

--- a/www/pages/documentation/dynamic-security.md
+++ b/www/pages/documentation/dynamic-security.md
@@ -215,7 +215,7 @@ set explicitly, priorities will default to -1.
 For each of the group, role, and ACL objects, checks are made in priority order
 from the highest numerical value to the lowest numerical value. If two objects
 of the same type have the same priority, then they will be checked in
-lexographical order according to the username/groupname/rolename, but it is
+lexicographical order according to the username/groupname/rolename, but it is
 advised to use unique priorities per object type.
 
 When an event occurs that needs an ACL check, the ACLs for that ACL type are
@@ -451,7 +451,7 @@ they would be provided on the command line. For example:
   the port defaults to 1883. If the scheme is mqtts:// then the port defaults
   to 8883.
 * `--nodelay` : Disable Nagle's algorithm for the socket. This means that
-  latency of sent messages is reduced, which is particularly noticable for
+  latency of sent messages is reduced, which is particularly noticeable for
   small, reasonably infrequent messages. Using this option may result in more
   packets being sent than would normally be necessary.
 * `-p port` : Connect to the port specified. If not given, the default of 1883

--- a/www/pages/documentation/migrating-to-2-0.md
+++ b/www/pages/documentation/migrating-to-2-0.md
@@ -184,7 +184,7 @@ Changes:
 
 ### Dependencies
 
-mosquitto_ctrl and mosquitto_dynamic_secuity.so require the cJSON library. If
+mosquitto_ctrl and mosquitto_dynamic_security.so require the cJSON library. If
 it is not detected or desired, those features can be disabled.
 
 ## Plugins

--- a/www/posts/2010/05/mosquitto-org.md
+++ b/www/posts/2010/05/mosquitto-org.md
@@ -9,6 +9,6 @@
 .. type: text
 -->
 
-I'm pleased to annouce that the mosquitto website is now available at
+I'm pleased to announce that the mosquitto website is now available at
 <http://mosquitto.org/> so please update your bookmarks! I'll be updating the
 links here in a few days when the change has propagated.

--- a/www/posts/2010/11/mosquitto-0-9test2.md
+++ b/www/posts/2010/11/mosquitto-0-9test2.md
@@ -37,7 +37,7 @@ I'm currently aware of:
 
 # Update
 I've uploaded test3 with a python fix, updated CMake scripts and fixed
-`max_inflight_messages` and `max_queued_mesages`.
+`max_inflight_messages` and `max_queued_messages`.
 
 [mosquitto-expt ppa]: https://launchpad.net/~mosquitto-dev/+archive/mosquitto-expt
 [openSUSE build service]: https://build.opensuse.org/project/show?project=home%3Aoojah%3Amqtt_expt

--- a/www/posts/2013/08/version-1-2-released.md
+++ b/www/posts/2013/08/version-1-2-released.md
@@ -95,7 +95,7 @@ available in the near future.
  * Add support for verifying remote server certificate subject against the
    remote hostname.
  * Add mosquitto_reconnect_async() support and make asynchronous connections
-   truely asynchronous rather than simply deferred. DNS lookups are still
+   truly asynchronous rather than simply deferred. DNS lookups are still
    blocking, so asynchronous connections require an IP address instead of
    hostname.
  * Allow control of reconnection timeouts in mosquitto_loop_forever() and after

--- a/www/posts/2015/08/version-1-4-3-released.md
+++ b/www/posts/2015/08/version-1-4-3-released.md
@@ -15,7 +15,7 @@ This is a bugfix release.
 
  * Fix incorrect bridge notification on initial connection. Closes [#467096].
  * Build fixes for OpenBSD.
- * Fix incorrect behaviour for `autosave_interval`, most noticable for
+ * Fix incorrect behaviour for `autosave_interval`, most noticeable for
    `autosave_interval=1`. Closes [#465438].
  * Fix handling of outgoing QoS&gt;0 messages for bridges that could not be
    sent because the bridge connection was down.

--- a/www/posts/2017/05/security-advisory-cve-2017-7650.md
+++ b/www/posts/2017/05/security-advisory-cve-2017-7650.md
@@ -40,7 +40,7 @@ Complete list of fixes addressed in version 1.4.12:
  * Fix mosquitto.db from becoming corrupted due to client messages being
    persisted with no stored message. Closes [#424].
  * Fix bridge not restarting properly. Closes [#428].
- * Fix unitialized memory in `gets_quiet` on Windows. Closes [#426].
+ * Fix uninitialized memory in `gets_quiet` on Windows. Closes [#426].
  * Fix building with `WITH_ADNS=no` for systems that don't use glibc. Closes
    [#415].
  * Fixes to readme.md.

--- a/www/posts/2019/11/version-1-6-8-released.md
+++ b/www/posts/2019/11/version-1-6-8-released.md
@@ -45,7 +45,7 @@ Mosquitto 1.6.8 has been released, this is a bugfix release.
   end with a new line. Closes [#1473].
 - Make documentation for `mosquitto_pub -l` match reality - blank lines are
   sent as empty messages. Closes [#1474].
-- Free memory in `mosquitto_sub` when quiting without having made a successful
+- Free memory in `mosquitto_sub` when quitting without having made a successful
   connection. Closes [#1513].
 
 # Build

--- a/www/posts/2020/12/version-2-0-0-released.md
+++ b/www/posts/2020/12/version-2-0-0-released.md
@@ -180,7 +180,7 @@ overall behaviour of a topic without having to see every message, for example.
   trust OS provided CA certificates for use with TLS connections.
 
 # Client library fixes
-- Fix send quota being incorrecly reset on reconnect. Closes [#1822].
+- Fix send quota being incorrectly reset on reconnect. Closes [#1822].
 - Don't use logging until log mutex is initialised. Closes [#1819].
 - Fix missing mach/mach_time.h header on OS X. Closes [#1831].
 - Fix connect properties not being sent when the client automatically

--- a/www/posts/2021/03/version-2-0-9-released.md
+++ b/www/posts/2021/03/version-2-0-9-released.md
@@ -28,7 +28,7 @@ bugfix releases and include a minor security fix.
 - Fix encrypted bridge connections incorrectly connecting when `bridge_cafile`
   is empty or invalid. Closes [#2130].
 - Fix `tls_version` behaviour not matching documentation. It was setting the
-  exact TLS version to use, not the minimium TLS version to use. Closes [#2110].
+  exact TLS version to use, not the minimum TLS version to use. Closes [#2110].
 - Fix messages to `$` prefixed topics being rejected. Closes [#2111].
 - Fix QoS 0 messages not being delivered when max_queued_bytes was configured.
   Closes [#2123].

--- a/www/posts/2021/08/version-2-0-12-released.md
+++ b/www/posts/2021/08/version-2-0-12-released.md
@@ -44,7 +44,7 @@ and bugfix release.
   These clients are now rejected if their keepalive value exceeds
   `max_keepalive`. This option allows CVE-2020-13849, which is for the MQTT
   v3.1.1 protocol itself rather than an implementation, to be addressed.
-- Fix broker not quiting if e.g. the `password_file` is specified as a
+- Fix broker not quitting if e.g. the `password_file` is specified as a
   directory. Closes [#2241].
 - Fix listener `mount_point` not being removed on outgoing messages.
   Closes [#2244].


### PR DESCRIPTION
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

Fix typos

with the config

```toml
[default.extend-words]
mosquitto = "mosquitto"
CAF = "CAF"
Leary = "Leary"
tpos = "tpos"
Jenkin = 'Jenkin'
Sur = "Sur"
exten = "exten"
clen = "clen"
WHT = "WHT"
Nam = "Nam"
Theramin = "Theramin"

[files]
extend-exclude = ["test"]
```
