### PR TITLE
Add context to ssl errors

### DIFF
--- a/lib/net_mosq.h
+++ b/lib/net_mosq.h
@@ -85,7 +85,7 @@ ssize_t net__read_ws(struct mosquitto *mosq, void *buf, size_t count);
 ssize_t net__write(struct mosquitto *mosq, const void *buf, size_t count);
 
 #ifdef WITH_TLS
-void net__print_ssl_error(struct mosquitto *mosq);
+void net__print_ssl_error(struct mosquitto *mosq, const char *msg);
 int net__socket_apply_tls(struct mosquitto *mosq);
 int net__socket_connect_tls(struct mosquitto *mosq);
 int mosquitto__verify_ocsp_status_cb(SSL * ssl, void *arg);

--- a/src/net.c
+++ b/src/net.c
@@ -500,7 +500,7 @@ static int net__load_crl_file(struct mosquitto__listener *listener)
 	if(rc < 1){
 		log__printf(NULL, MOSQ_LOG_ERR, "Error: Unable to load certificate revocation file \"%s\". Check crlfile.", listener->crlfile);
 		net__print_error(MOSQ_LOG_ERR, "Error: %s");
-		net__print_ssl_error(NULL);
+		net__print_ssl_error(NULL, NULL);
 		return MOSQ_ERR_TLS;
 	}
 	X509_STORE_set_flags(store, X509_V_FLAG_CRL_CHECK);
@@ -523,21 +523,21 @@ int net__load_certificates(struct mosquitto__listener *listener)
 	rc = SSL_CTX_use_certificate_chain_file(listener->ssl_ctx, listener->certfile);
 	if(rc != 1){
 		log__printf(NULL, MOSQ_LOG_ERR, "Error: Unable to load server certificate \"%s\". Check certfile.", listener->certfile);
-		net__print_ssl_error(NULL);
+		net__print_ssl_error(NULL, NULL);
 		return MOSQ_ERR_TLS;
 	}
 	if(listener->tls_engine == NULL || listener->tls_keyform == mosq_k_pem){
 		rc = SSL_CTX_use_PrivateKey_file(listener->ssl_ctx, listener->keyfile, SSL_FILETYPE_PEM);
 		if(rc != 1){
 			log__printf(NULL, MOSQ_LOG_ERR, "Error: Unable to load server key file \"%s\". Check keyfile.", listener->keyfile);
-			net__print_ssl_error(NULL);
+			net__print_ssl_error(NULL, NULL);
 			return MOSQ_ERR_TLS;
 		}
 	}
 	rc = SSL_CTX_check_private_key(listener->ssl_ctx);
 	if(rc != 1){
 		log__printf(NULL, MOSQ_LOG_ERR, "Error: Server certificate/key are inconsistent.");
-		net__print_ssl_error(NULL);
+		net__print_ssl_error(NULL, NULL);
 		return MOSQ_ERR_TLS;
 	}
 	/* Load CRLs if they exist. */
@@ -568,12 +568,12 @@ static int net__load_engine(struct mosquitto__listener *listener)
 	engine = ENGINE_by_id(listener->tls_engine);
 	if(!engine){
 		log__printf(NULL, MOSQ_LOG_ERR, "Error loading %s engine\n", listener->tls_engine);
-		net__print_ssl_error(NULL);
+		net__print_ssl_error(NULL, NULL);
 		return MOSQ_ERR_TLS;
 	}
 	if(!ENGINE_init(engine)){
 		log__printf(NULL, MOSQ_LOG_ERR, "Failed engine initialisation\n");
-		net__print_ssl_error(NULL);
+		net__print_ssl_error(NULL, NULL);
 		return MOSQ_ERR_TLS;
 	}
 	ENGINE_set_default(engine, ENGINE_METHOD_ALL);
@@ -583,12 +583,12 @@ static int net__load_engine(struct mosquitto__listener *listener)
 		if(listener->tls_engine_kpass_sha1){
 			if(!ENGINE_ctrl_cmd(engine, ENGINE_SECRET_MODE, ENGINE_SECRET_MODE_SHA, NULL, NULL, 0)){
 				log__printf(NULL, MOSQ_LOG_ERR, "Error: Unable to set engine secret mode sha");
-				net__print_ssl_error(NULL);
+				net__print_ssl_error(NULL, NULL);
 				return MOSQ_ERR_TLS;
 			}
 			if(!ENGINE_ctrl_cmd(engine, ENGINE_PIN, 0, listener->tls_engine_kpass_sha1, NULL, 0)){
 				log__printf(NULL, MOSQ_LOG_ERR, "Error: Unable to set engine pin");
-				net__print_ssl_error(NULL);
+				net__print_ssl_error(NULL, NULL);
 				return MOSQ_ERR_TLS;
 			}
 			ui_method = NULL;
@@ -596,12 +596,12 @@ static int net__load_engine(struct mosquitto__listener *listener)
 		pkey = ENGINE_load_private_key(engine, listener->keyfile, ui_method, NULL);
 		if(!pkey){
 			log__printf(NULL, MOSQ_LOG_ERR, "Error: Unable to load engine private key file \"%s\".", listener->keyfile);
-			net__print_ssl_error(NULL);
+			net__print_ssl_error(NULL, NULL);
 			return MOSQ_ERR_TLS;
 		}
 		if(SSL_CTX_use_PrivateKey(listener->ssl_ctx, pkey) <= 0){
 			log__printf(NULL, MOSQ_LOG_ERR, "Error: Unable to use engine private key file \"%s\".", listener->keyfile);
-			net__print_ssl_error(NULL);
+			net__print_ssl_error(NULL, NULL);
 			return MOSQ_ERR_TLS;
 		}
 	}
@@ -635,7 +635,7 @@ int net__tls_load_verify(struct mosquitto__listener *listener)
 		rc = SSL_CTX_load_verify_file(listener->ssl_ctx, listener->cafile);
 		if(rc == 0){
 			log__printf(NULL, MOSQ_LOG_ERR, "Error: Unable to load CA certificates. Check cafile \"%s\".", listener->cafile);
-			net__print_ssl_error(NULL);
+			net__print_ssl_error(NULL, NULL);
 			return MOSQ_ERR_TLS;
 		}
 	}
@@ -643,7 +643,7 @@ int net__tls_load_verify(struct mosquitto__listener *listener)
 		rc = SSL_CTX_load_verify_dir(listener->ssl_ctx, listener->capath);
 		if(rc == 0){
 			log__printf(NULL, MOSQ_LOG_ERR, "Error: Unable to load CA certificates. Check capath \"%s\".", listener->capath);
-			net__print_ssl_error(NULL);
+			net__print_ssl_error(NULL, NULL);
 			return MOSQ_ERR_TLS;
 		}
 	}
@@ -969,7 +969,7 @@ int net__socket_listen(struct mosquitto__listener *listener)
 				rc = SSL_CTX_use_psk_identity_hint(listener->ssl_ctx, listener->psk_hint);
 				if(rc == 0){
 					log__printf(NULL, MOSQ_LOG_ERR, "Error: Unable to set TLS PSK hint.");
-					net__print_ssl_error(NULL);
+					net__print_ssl_error(NULL, NULL);
 					return 1;
 				}
 			}


### PR DESCRIPTION
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?


Hi this fix allow the user to have more context on the ssl error