### PR TITLE
feat: add mqtt_protocol.h indication

### DIFF
--- a/include/mosquitto/libcommon_properties.h
+++ b/include/mosquitto/libcommon_properties.h
@@ -187,7 +187,7 @@ libmosqcommon_EXPORT int mosquitto_property_add_string(mosquitto_property **prop
  *
  * Parameters:
  *	proplist - pointer to mosquitto_property pointer, the list of properties
- *	identifier - property identifier (e.g. MQTT_PROP_USER_PROPERTY)
+ *	identifier - MQTT property identifier (e.g. MQTT_PROP_USER_PROPERTY from <mosquitto/mqtt_protocol.h>)
  *	name - string name for the new property, must be UTF-8 and zero terminated
  *	value - string value for the new property, must be UTF-8 and zero terminated
  *
@@ -672,7 +672,7 @@ libmosqcommon_EXPORT int mosquitto_property_copy_all(mosquitto_property **dest, 
  *
  * Parameters:
  *   command - MQTT command (e.g. CMD_CONNECT)
- *   identifier - MQTT property (e.g. MQTT_PROP_USER_PROPERTY)
+ *	identifier - MQTT property identifier (e.g. MQTT_PROP_USER_PROPERTY from <mosquitto/mqtt_protocol.h>)
  *
  * Returns:
  *   MOSQ_ERR_SUCCESS - if the identifier is valid for command
@@ -711,7 +711,7 @@ libmosqcommon_EXPORT int mosquitto_property_check_all(int command, const mosquit
  * separator, for example: payload-format-indicator.
  *
  * Parameters:
- *	identifier - valid MQTT property identifier integer
+ *	identifier - MQTT property identifier (e.g. MQTT_PROP_USER_PROPERTY from <mosquitto/mqtt_protocol.h>)
  *
  * Returns:
  *  A const string to the property name on success


### PR DESCRIPTION
- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

Mention the existence of  `<mqtt_protocol.h>`

<img width="665" height="132" alt="image" src="https://github.com/user-attachments/assets/75688a2f-0462-4de9-a7c7-95886f5be16f" />

<img width="540" height="61" alt="image" src="https://github.com/user-attachments/assets/138db1fc-8cbe-4f48-9bdd-b3580b2f9084" />
