### PR TITLE
Fix expiry list corruption

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -235,7 +235,9 @@ void context__disconnect(struct mosquitto *context)
 				context__add_to_disused(context);
 			}
 		}else{
-			session_expiry__add(context);
+			if (!context->expiry_list_item) {
+				session_expiry__add(context);
+			}
 		}
 	}
 	keepalive__remove(context);


### PR DESCRIPTION
The internal expiry list can be corrupted if a client connects with a nonzero session expiration time, they disconnect, a plugin kicks said client, and mosquitto expires their session (in that order). The issue arises because the client context is added to the expiry_list twice. Fix this by first checking if the client is already on the list before adding them again.

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

