### PR TITLE
update: Generic Dockerfile README to note config provided via mount point

### DIFF
--- a/docker/generic/README.md
+++ b/docker/generic/README.md
@@ -2,12 +2,21 @@
 Containers built with this Dockerfile build as source from published tarballs.
 
 ## Mount Points
-Three docker volumes have been created in the image to be used for configuration, persistent storage and logs.
+A docker mount point has been created in the image to be used for configuration.
 ```
 /mosquitto/config
+```
+
+Two docker volumes have been created in the image to be used for persistent storage and logs.
+```
 /mosquitto/data
 /mosquitto/log
 ```
+
+## User/Group
+
+The image runs mosquitto under the mosquitto user and group, which are created
+with a uid and gid of 1883.
 
 ## Running without a configuration file
 Mosquitto 2.0 requires you to configure listeners and authentication before it


### PR DESCRIPTION
Addressing https://github.com/eclipse-mosquitto/mosquitto/issues/3346

Updated the generic docker README with the appropriate instructions for mounting configuration, matching the other docker READMEs.

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
