### PR TITLE
Add configure-time check for -lanl

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -318,8 +318,11 @@ ifeq ($(WITH_EC),yes)
 endif
 
 ifeq ($(WITH_ADNS),yes)
-	BROKER_LDADD:=$(BROKER_LDADD) -lanl
 	BROKER_CPPFLAGS:=$(BROKER_CPPFLAGS) -DWITH_ADNS
+	NEED_LIBANL := $(shell printf '#include <stdlib.h>\n#include <netdb.h>\nint main(){return getaddrinfo_a(0, NULL, 0, NULL);}'| $(CC) -D_GNU_SOURCE -o /dev/null -x c - 2>/dev/null || echo YES)
+	ifeq ($(NEED_LIBANL),YES)
+		BROKER_LDADD:=$(BROKER_LDADD) -lanl
+	endif
 endif
 
 ifeq ($(WITH_CONTROL),yes)


### PR DESCRIPTION
Since glibc 2.34, libanl features have been integrated directly into libc [1].
For backward compatibility, some toolchains still provide a shim for
libanl as a separate .so, but new toolchains (for example for new archs
like loongarch) do not provide it anymore.

In such a case, building mosquitto fails at link time with (see [2])
    > cannot find -lanl: No such file or directory

To fix this problem while maintaining compatibility with older toolchains,
check if a simple program that uses libanl can be compiled without -lanl,
and only add the linker flag otherwise.

[1] https://sourceware.org/pipermail/libc-alpha/2021-August/129718.html
[2] https://autobuild.buildroot.org/results/16223cd838876abc9b6f941f7dc20d23afa32c3b/build-end.log

Signed-off-by: Titouan Christophe <titouan.christophe@mind.be>

Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [ ] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [ ] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `make test` with your changes locally?

-----
