### PR TITLE
fix: fix session persistence bug when per_listener_settings is enabled

### DIFF
--- a/lib/net_mosq.c
+++ b/lib/net_mosq.c
@@ -259,9 +259,8 @@ int net__socket_close(struct mosquitto *mosq)
 	}
 
 #ifdef WITH_BROKER
-	if(mosq->listener){
+	if(mosq->listener && mosq->state != mosq_cs_duplicate && mosq->state != mosq_cs_disused){
 		mosq->listener->client_count--;
-		mosq->listener = NULL;
 	}
 #endif
 


### PR DESCRIPTION
Fixing a long standing issue which has affected mosquitto since >=2.0.12. The issue was that when using the setting `per_listener_settings true`, the session persistence would fail resulting in messages being dropped / not being delivered when the client reconnects when using session persistence.

The change was originally suggested by @llamaonaskateboard in https://github.com/eclipse-mosquitto/mosquitto/issues/2618/#issuecomment-2208677071

Resolves https://github.com/eclipse-mosquitto/mosquitto/issues/2618 and https://github.com/eclipse-mosquitto/mosquitto/issues/2526
