### PR TITLE
Add support for OpenSSL provider URIs

### DIFF
--- a/apps/mosquitto_ctrl/options.c
+++ b/apps/mosquitto_ctrl/options.c
@@ -623,7 +623,7 @@ int client_opts_set(struct mosquitto *mosq, struct mosq_config *cfg)
 	}
 #ifdef WITH_TLS
 	if(cfg->keyform && mosquitto_string_option(mosq, MOSQ_OPT_TLS_KEYFORM, cfg->keyform)){
-		fprintf(stderr, "Error: Problem setting key form, it must be one of 'pem' or 'engine'.\n");
+		fprintf(stderr, "Error: Problem setting key form, it must be one of 'pem', 'engine', or 'uri'.\n");
 		return 1;
 	}
 	if(cfg->cafile || cfg->capath){

--- a/client/client_shared.c
+++ b/client/client_shared.c
@@ -1370,6 +1370,11 @@ static int client_tls_opts_set(struct mosquitto *mosq, struct mosq_config *cfg)
 		SSL_CTX_set_keylog_callback(cfg->ssl_ctx, tls_keylog_callback);
 	}
 
+	/* keyform must be known before calling mosquitto_tls_set() */
+	if(cfg->keyform && mosquitto_string_option(mosq, MOSQ_OPT_TLS_KEYFORM, cfg->keyform)){
+		err_printf(cfg, "Error: Problem setting key form, it must be one of 'pem', 'engine' or 'uri'.\n");
+		return 1;
+	}
 	if(cfg->cafile || cfg->capath){
 		rc = mosquitto_tls_set(mosq, cfg->cafile, cfg->capath, cfg->certfile, cfg->keyfile, NULL);
 		if(rc){
@@ -1400,10 +1405,6 @@ static int client_tls_opts_set(struct mosquitto *mosq, struct mosq_config *cfg)
 	}
 	if(cfg->tls_engine && mosquitto_string_option(mosq, MOSQ_OPT_TLS_ENGINE, cfg->tls_engine)){
 		err_printf(cfg, "Error: Problem setting TLS engine, is %s a valid engine?\n", cfg->tls_engine);
-		return 1;
-	}
-	if(cfg->keyform && mosquitto_string_option(mosq, MOSQ_OPT_TLS_KEYFORM, cfg->keyform)){
-		err_printf(cfg, "Error: Problem setting key form, it must be one of 'pem' or 'engine'.\n");
 		return 1;
 	}
 	if(cfg->tls_engine_kpass_sha1 && mosquitto_string_option(mosq, MOSQ_OPT_TLS_ENGINE_KPASS_SHA1, cfg->tls_engine_kpass_sha1)){

--- a/client/pub_client.c
+++ b/client/pub_client.c
@@ -505,7 +505,7 @@ static void print_usage(void)
 	printf("            communication.\n");
 	printf(" --cert : client certificate for authentication, if required by server.\n");
 	printf(" --key : client private key for authentication, if required by server.\n");
-	printf(" --keyform : keyfile type, can be either \"pem\" or \"engine\".\n");
+	printf(" --keyform : keyfile type, can be \"pem\", \"engine\", or \"uri\".\n");
 	printf(" --ciphers : openssl compatible list of TLS ciphers to support.\n");
 	printf(" --tls-version : TLS protocol version, can be one of tlsv1.3 or tlsv1.2.\n");
 	printf("                 Defaults to tlsv1.2 if available.\n");

--- a/client/sub_client.c
+++ b/client/sub_client.c
@@ -344,7 +344,7 @@ static void print_usage(void)
 	printf("            communication.\n");
 	printf(" --cert : client certificate for authentication, if required by server.\n");
 	printf(" --key : client private key for authentication, if required by server.\n");
-	printf(" --keyform : keyfile type, can be either \"pem\" or \"engine\".\n");
+	printf(" --keyform : keyfile type, can be \"pem\", \"engine\", or \"uri\".\n");
 	printf(" --ciphers : openssl compatible list of TLS ciphers to support.\n");
 	printf(" --tls-version : TLS protocol version, can be one of tlsv1.3 or tlsv1.2.\n");
 	printf("                 Defaults to tlsv1.2 if available.\n");

--- a/include/mosquitto/libmosquitto_options.h
+++ b/include/mosquitto/libmosquitto_options.h
@@ -172,9 +172,12 @@ libmosq_EXPORT int mosquitto_int_option(struct mosquitto *mosq, enum mosq_opt_t 
  *	MOSQ_OPT_TLS_KEYFORM - Configure the client to treat the keyfile
  *	          differently depending on its type.  Must be set
  *	          before <mosquitto_connect>.
- *	          Set as either "pem" or "engine", to determine from where the
+ *	          Set as "pem", "engine", or "uri" to determine from where the
  *	          private key for a TLS connection will be obtained. Defaults to
  *	          "pem", a normal private key file.
+ *	          "engine" allows private keys operations via an OpenSSL engine.
+ *	          "uri" is available with OpenSSL 3.0 or later, and allows keys
+ *	          to be referenced through OpenSSL provider URIs such as pkcs11: URIs.
  *
  *	MOSQ_OPT_TLS_ENGINE_KPASS_SHA1 - Where the TLS Engine requires the use of
  *	          a password to be accessed, this option allows a hex encoded

--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -222,6 +222,7 @@ struct mosquitto_message_all {
 enum mosquitto__keyform {
 	mosq_k_pem = 0,
 	mosq_k_engine = 1,
+	mosq_k_uri = 2,
 };
 #endif
 

--- a/man/common/option-tls-keyform.xml
+++ b/man/common/option-tls-keyform.xml
@@ -3,10 +3,15 @@
 	<listitem>
 		<para>
 			Specifies the type of private key in use when making TLS
-			connections.. This can be "pem" or "engine". This parameter is
+			connections. This can be "pem", "engine", or "uri". This parameter is
 			useful when a TPM module is being used and the private key has been
 			created with it. Defaults to "pem", which means normal private key
 			files are used.
+		</para>
+		<para>
+			The "engine" option allows private keys operations via an OpenSSL engine.
+			The "uri" option is available with OpenSSL 3.0 or later, and allows
+			keys to be referenced through OpenSSL provider URIs such as pkcs11: URIs.
 		</para>
 		<para>
 			See also <option>--tls-engine</option>.

--- a/man/common/synopsis-tls-certificate-options.xml
+++ b/man/common/synopsis-tls-certificate-options.xml
@@ -24,6 +24,7 @@
 	<group choice='req'>
 		<arg choice='plain'><replaceable>pem</replaceable></arg>
 		<arg choice='plain'><replaceable>engine</replaceable></arg>
+		<arg choice='plain'><replaceable>uri</replaceable></arg>
 	</group></arg>
 	<arg><option>--tls-engine-kpass-sha1</option> <replaceable>kpass-sha1</replaceable></arg>
 	<sbr/>

--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -1882,6 +1882,8 @@ openssl dhparam -out dhparam.pem 2048</programlisting>
 							to enable certificate based TLS encryption. If
 							<option>tls_keyform</option> is "engine" this represents
 							the engine handle of the private key.
+							If <option>tls_keyform</option> is "uri" this represents
+							the OpenSSL provider URI for the key, e.g. pkcs11: URIs.
 						</para>
 						<para>
 							The private key pointed to by this option will be
@@ -1928,14 +1930,18 @@ openssl dhparam -out dhparam.pem 2048</programlisting>
 					</listitem>
 				</varlistentry>
 				<varlistentry>
-					<term><option>tls_keyform</option> [ pem | engine ]</term>
+					<term><option>tls_keyform</option> [ pem | engine | uri ]</term>
 					<listitem>
 						<para>Specifies the type of private key in use when
-							making TLS connections.. This can be "pem" or
-							"engine". This parameter is useful when a TPM
+							making TLS connections. This can be "pem", "engine",
+							or "uri". This parameter is useful when a TPM
 							module is being used and the private key has been
 							created with it. Defaults to "pem", which means
 							normal private key files are used.</para>
+						<para>The "engine" option is only available with OpenSSL &lt; 3.0.
+							The "uri" option is only available with OpenSSL &gt;= 3.0,
+							and allows the key to be obtained from URIs such as
+							pkcs11: URIs.</para>
 					</listitem>
 				</varlistentry>
 				<varlistentry>

--- a/src/conf.c
+++ b/src/conf.c
@@ -2691,6 +2691,8 @@ static int config__read_file_core(struct mosquitto__config *config, bool reload,
 					cur_listener->tls_keyform = mosq_k_pem;
 					if(!strcmp(keyform, "engine")){
 						cur_listener->tls_keyform = mosq_k_engine;
+					}else if(!strcmp(keyform, "uri")){
+						cur_listener->tls_keyform = mosq_k_uri;
 					}
 					mosquitto_FREE(keyform);
 #else

--- a/test/apps/ctrl/ctrl-args.py
+++ b/test/apps/ctrl/ctrl-args.py
@@ -36,7 +36,7 @@ do_test(["-i"], 1, response="Error: -i argument given but no id specified.\n\n")
 do_test(["--keyform"], 1, response="Error: --keyform argument given but no keyform specified.\n\n")
 do_test(["--keyform", "key"], 1, response="Error: If keyform is set, keyfile must be also specified.\n")
 do_test(["--keyform", "key", "--cafile", "file", "--cert", "file", "--key", "file", "broker", "listListeners"], 1,
-        response="Error: Problem setting key form, it must be one of 'pem' or 'engine'.\n")
+        response="Error: Problem setting key form, it must be one of 'pem', 'engine', or 'uri'.\n")
 do_test(['-L'], 1, response="Error: -L argument given but no URL specified.\n\n")
 do_test(['-L', 'invalid://'], 1, response="Error: Unsupported URL scheme.\n\n")
 do_test(['-L', 'mqtt://localhost'], 1, response="Error: Invalid URL for -L argument specified - topic missing.\n")


### PR DESCRIPTION
Mosquitto currently does not support OpenSSL 3 provider-based key URIs.
In OpenSSL 3 and later, URIs are used to reference private keys and key stores via the provider and STORE APIs (for example, pkcs11: URIs, but this can be any other URI scheme supported by a given provider). This mechanism replaces the legacy engine-based approach used in earlier OpenSSL versions.
According to the OpenSSL roadmap, engine support is deprecated and scheduled for removal in OpenSSL 4, requiring applications that rely on engines to migrate to provider-based implementations.
This pull request introduces a new keyform option, uri. When keyform is set to uri, Mosquitto uses the OpenSSL STORE API to load private keys via provider URIs, enabling compatibility with OpenSSL 3 providers and future OpenSSL releases.

The change has been validated  using either a URI private key reference at client side (e.g. mosquitto_sub) and at broker side.

----
Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if
you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
If you aren't able to do that, or just don't want to, please describe your bug
fix/feature change in an issue. For simple bug fixes it is can be just as easy
for us to be told about the problem and then go fix it directly.

Then please check the following list of things we ask for in your pull request:

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [x] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

-----
