### PR TITLE
fix: send Malformed Packet CONNACK for invalid Will QoS=3 in MQTT 5.0

### DIFF
--- a/src/handle_connect.c
+++ b/src/handle_connect.c
@@ -651,7 +651,10 @@ static int verify_will_options(struct mosquitto *context, uint8_t will, uint8_t 
 	if(will_qos == 3){
 		log__printf(NULL, MOSQ_LOG_INFO, "Protocol error from %s:%d: CONNECT with invalid Will QoS (%d).",
 				context->address, context->remote_port, will_qos);
-		return MOSQ_ERR_PROTOCOL;
+		if(protocol_version == mosq_p_mqtt5){
+			send__connack(context, 0, MQTT_RC_MALFORMED_PACKET, NULL);
+		}
+		return MOSQ_ERR_MALFORMED_PACKET;
 	}
 
 	if(will && will_retain && db.config->retain_available == false){


### PR DESCRIPTION
## Problem

When a MQTT 5.0 CONNECT packet contains `Will QoS=3` (an invalid value per [MQTT-3.1.2-7]), Mosquitto silently closes the connection without sending a CONNACK packet.

Per the MQTT 5.0 OASIS specification §3.1.2.5, Will QoS is a 2-bit field with valid values 0, 1, 2. QoS=3 is reserved and must be rejected.

## Current Behavior

```c
// verify_will_options() in handle_connect.c
if(will_qos == 3){
    log__printf(NULL, MOSQ_LOG_INFO, "Protocol error ...");
    return MOSQ_ERR_PROTOCOL;  // Connection closed without CONNACK
}
```

## Expected Behavior

Per [MQTT-3.1.2-7] and §4.13, the server should send a CONNACK with Reason Code `0x81` (Malformed Packet) before closing the connection.

## Fix

```c
if(will_qos == 3){
    log__printf(NULL, MOSQ_LOG_INFO, "Protocol error ...");
    if(protocol_version == mosq_p_mqtt5){
        send__connack(context, 0, MQTT_RC_MALFORMED_PACKET, NULL);
    }
    return MOSQ_ERR_MALFORMED_PACKET;
}
```

## Test Case

Verified with an automated MQTT 5.0 conformance test (T-64) that sends CONNECT with Will QoS=3 and expects a CONNACK with Reason Code 0x81.

## References

- MQTT 5.0 OASIS Standard (2019-03-07), §3.1.2.5: Will QoS
- [MQTT-3.1.2-7]: If Will Flag is set to 1, the value of Will QoS can be 0 (0x00), 1 (0x01), or 2 (0x10)