### PR TITLE
fix: send Malformed Packet CONNACK for Will flag=0 with non-zero QoS/retain in MQTT 5.0

### DIFF
--- a/src/handle_connect.c
+++ b/src/handle_connect.c
@@ -1163,7 +1163,10 @@ int handle__connect(struct mosquitto *context)
 			if(will_qos != 0 || will_retain != 0){
 				log__printf(NULL, MOSQ_LOG_INFO, "Protocol error from %s: CONNECT without Will with non-zero QoS (%d) or retain (%d).",
 						clientid, will_qos, will_retain);
-				rc = MOSQ_ERR_PROTOCOL;
+				if(context->protocol == mosq_p_mqtt5){
+					send__connack(context, 0, MQTT_RC_MALFORMED_PACKET, NULL);
+				}
+				rc = MOSQ_ERR_MALFORMED_PACKET;
 				goto handle_connect_error;
 			}
 		}


### PR DESCRIPTION
## Problem

When a MQTT 5.0 CONNECT packet has `Will Flag=0` but `Will QoS != 0` or `Will Retain=1`, Mosquitto silently closes the connection without sending a CONNACK packet.

Per the MQTT 5.0 OASIS specification §3.1.2.5 and §3.1.2.7, if Will Flag is set to 0, Will QoS and Will Retain must both be 0.

## Current Behavior

```c
// handle__connect() in handle_connect.c
if(will_qos != 0 || will_retain != 0){
    log__printf(NULL, MOSQ_LOG_INFO, "Protocol error ...");
    rc = MOSQ_ERR_PROTOCOL;  // Connection closed without CONNACK
    goto handle_connect_error;
}
```

## Expected Behavior

Per [MQTT-3.1.2-5] and [MQTT-3.1.2-7], the server should send a CONNACK with Reason Code `0x81` (Malformed Packet) before closing the connection.

## Fix

```c
if(will_qos != 0 || will_retain != 0){
    log__printf(NULL, MOSQ_LOG_INFO, "Protocol error ...");
    if(context->protocol == mosq_p_mqtt5){
        send__connack(context, 0, MQTT_RC_MALFORMED_PACKET, NULL);
    }
    rc = MOSQ_ERR_MALFORMED_PACKET;
    goto handle_connect_error;
}
```

## Test Cases

Verified with automated MQTT 5.0 conformance tests:
- T-85: Will Flag=0, Will QoS=1 → expects CONNACK 0x81
- T-86: Will Flag=0, Will QoS=2 → expects CONNACK 0x81
- T-87: Will Flag=0, Will Retain=1 → expects CONNACK 0x81

## References

- MQTT 5.0 OASIS Standard (2019-03-07), §3.1.2.5: Will QoS, §3.1.2.7: Will Retain
- [MQTT-3.1.2-5]: If Will Flag is set to 0, Will QoS MUST be set to 0
- [MQTT-3.1.2-7]: If Will Flag is set to 0, Will Retain MUST be set to 0