### PR TITLE
fix: send Malformed Packet CONNACK for username parse error in MQTT 5.0

### DIFF
--- a/src/handle_connect.c
+++ b/src/handle_connect.c
@@ -809,6 +809,9 @@ static int read_and_verify_client_credentials_from_packet(struct mosquitto *cont
 	if(username_flag){
 		rc = set_username_from_packet(context, username, clientid);
 		if(rc != MOSQ_ERR_SUCCESS){
+			if(context->protocol == mosq_p_mqtt5){
+				send__connack(context, 0, MQTT_RC_MALFORMED_PACKET, NULL);
+			}
 			return rc;
 		}
 	}else{


### PR DESCRIPTION
## Problem

When a MQTT 5.0 CONNECT packet has the Username Flag set but the username field is missing or contains invalid data, Mosquitto silently closes the connection without sending a CONNACK packet.

Per the MQTT 5.0 OASIS specification §3.1.2.11, if the Username Flag is set to 1, the Username must be present as a valid UTF-8 encoded string.

## Current Behavior

```c
// read_and_verify_client_credentials_from_packet() in handle_connect.c
if(username_flag){
    rc = set_username_from_packet(context, username, clientid);
    if(rc != MOSQ_ERR_SUCCESS){
        return rc;  // Connection closed without CONNACK
    }
}
```

## Expected Behavior

Per [MQTT-3.1.2-11] and §4.13, the server should send a CONNACK with Reason Code `0x81` (Malformed Packet) before closing the connection.

## Fix

```c
if(username_flag){
    rc = set_username_from_packet(context, username, clientid);
    if(rc != MOSQ_ERR_SUCCESS){
        if(context->protocol == mosq_p_mqtt5){
            send__connack(context, 0, MQTT_RC_MALFORMED_PACKET, NULL);
        }
        return rc;
    }
}
```

## Test Case

Verified with an automated MQTT 5.0 conformance test (T-92) that sends CONNECT with Username Flag=1 but no username data, and expects a CONNACK with Reason Code 0x81.

## References

- MQTT 5.0 OASIS Standard (2019-03-07), §3.1.2.11: User Name Flag
- [MQTT-3.1.2-11]: If User Name Flag is set to 1, the User Name must be present