### PR TITLE
fix: skip persistence backup when testing configuration

### DIFF
--- a/src/mosquitto.c
+++ b/src/mosquitto.c
@@ -353,7 +353,9 @@ static void post_shutdown_cleanup(void)
 	broker_control__cleanup();
 
 #ifdef WITH_PERSISTENCE
-	persist__backup(true);
+	if(db.config && !db.config->test_configuration){
+		persist__backup(true);
+	}
 #endif
 	session_expiry__remove_all();
 


### PR DESCRIPTION
## Fixes #3712

### Problem
`mosquitto --test-config -c <config>` with built-in persistence enabled silently overwrites an existing persistence database with an empty one. The `--test-config` flag is documented as not starting the broker, but `post_shutdown_cleanup()` calls `persist__backup(true)` which writes the current (empty) in-memory database to disk, destroying retained messages, persistent client sessions, subscriptions, and queued client messages.

### Root Cause
In `src/mosquitto.c`, the `--test-config` early-return path calls `post_shutdown_cleanup()`, which unconditionally calls `persist__backup(true)` via:

```c
#ifdef WITH_PERSISTENCE
    persist__backup(true);
#endif
```

At this point the database has only been initialized with `memset(&db, 0, ...)` — no data has been loaded. The backup writes an empty database file, overwriting the existing one.

### Fix
Guard `persist__backup(true)` so it is skipped when `test_configuration` is true. The persistence database is only meaningful when the broker is actually running.

### Change
- `src/mosquitto.c`: +3/-1 lines in `post_shutdown_cleanup()`
