### PR TITLE
feature addition: docker image supporting PUID/PGID

### DIFF
--- a/docker/2.1-appuser/Dockerfile
+++ b/docker/2.1-appuser/Dockerfile
@@ -24,8 +24,8 @@ ENV PGID=${GID}
 
 RUN set -x && \
     apk --no-cache add \
-        daemontools-encore \
         shadow \
+        tini \
         && \
     apk --no-cache add --virtual build-deps \
         argon2-dev \
@@ -111,5 +111,5 @@ VOLUME ["/mosquitto/data", "/mosquitto/log"]
 # Set up the entry point script and default command
 COPY --chmod=0755 docker-entrypoint.sh /
 EXPOSE 1883
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini","-g", "--", "/docker-entrypoint.sh"]
 CMD ["/usr/sbin/mosquitto", "-c", "/mosquitto/config/mosquitto.conf"]

--- a/docker/2.1-appuser/Dockerfile
+++ b/docker/2.1-appuser/Dockerfile
@@ -1,0 +1,115 @@
+FROM alpine:3.23
+
+ENV VERSION=2.1.2 \
+    DOWNLOAD_SHA256=fd905380691ac65ea5a93779e8214941829e3d6e038d5edff9eac5fd74cbed02 \
+    GPG_KEYS=A0D6EEA1DCAE49A635A3B2F0779B22DFB3E717B7
+
+LABEL \
+    org.opencontainers.image.authors="Roger Light <roger@atchoo.org>" \
+    org.opencontainers.image.title="eclipse-mosquitto" \
+    org.opencontainers.image.description="Eclipse Mosquitto MQTT Broker" \
+    org.opencontainers.image.url="https://mosquitto.org/" \
+    org.opencontainers.image.documentation="https://mosquitto.org/documentation/" \
+    org.opencontainers.image.source="https://github.com/eclipse-mosquitto/mosquitto" \
+    org.opencontainers.image.licenses="EPL-2.0 OR BSD-3-Clause" \
+    org.opencontainers.image.version=${VERSION}
+
+# UID/GID will set the mosquitto UID/GID at build time (Dockerfile)
+ARG UID=1883
+ARG GID=1883
+# PUID/PGID will set the mosquitto UID/GID at run time (docker-entrypoint.sh)
+# and run mosquitto under the changed user
+ENV PUID=${UID}
+ENV PGID=${GID}
+
+RUN set -x && \
+    apk --no-cache add \
+        daemontools-encore \
+        shadow \
+        && \
+    apk --no-cache add --virtual build-deps \
+        argon2-dev \
+        build-base \
+        cjson-dev \
+        cmake \
+        cunit-dev \
+        gnupg \
+        gtest-dev \
+        libedit-dev \
+        libmicrohttpd-dev \
+        linux-headers \
+        openssl-dev \
+        samurai \
+        sqlite-dev \
+        uthash-dev \
+        util-linux-dev && \
+    wget https://mosquitto.org/files/source/mosquitto-${VERSION}.tar.gz -O /tmp/mosq.tar.gz && \
+    echo "$DOWNLOAD_SHA256  /tmp/mosq.tar.gz" | sha256sum -c - && \
+    wget https://mosquitto.org/files/source/mosquitto-${VERSION}.tar.gz.asc -O /tmp/mosq.tar.gz.asc && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    found=''; \
+    for server in \
+        hkps://keys.openpgp.org \
+        hkp://keyserver.ubuntu.com:80 \
+        pgp.mit.edu \
+    ; do \
+        echo "Fetching GPG key $GPG_KEYS from $server"; \
+        gpg --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$GPG_KEYS" && found=yes && break; \
+    done; \
+    test -z "$found" && echo >&2 "error: failed to fetch GPG key $GPG_KEYS" && exit 1; \
+    gpg --batch --verify /tmp/mosq.tar.gz.asc /tmp/mosq.tar.gz && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" /tmp/mosq.tar.gz.asc && \
+    mkdir -p /build/mosq && \
+    tar --strip=1 -xf /tmp/mosq.tar.gz -C /build/mosq && \
+    rm /tmp/mosq.tar.gz && \
+    cmake -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DHTTP_API_DIR='\"/usr/share/mosquitto/dashboard\"' \
+        -DWITH_DOCS=OFF \
+        -S /build/mosq \
+        -B /build/mosq/build && \
+    cmake --build /build/mosq/build && \
+    addgroup -S -g "${PGID}" mosquitto 2>/dev/null && \
+    adduser -S -u "${PUID}" -D -H -h /var/empty -s /sbin/nologin -G mosquitto -g mosquitto mosquitto 2>/dev/null && \
+    mkdir -p /mosquitto/config /mosquitto/data /mosquitto/log && \
+    install -d /usr/sbin/ && \
+    install -s -m755 /build/mosq/build/client/mosquitto_pub /usr/bin/mosquitto_pub && \
+    install -s -m755 /build/mosq/build/client/mosquitto_rr /usr/bin/mosquitto_rr && \
+    install -s -m755 /build/mosq/build/client/mosquitto_sub /usr/bin/mosquitto_sub && \
+    install -s -m644 /build/mosq/build/lib/libmosquitto.so.1 /usr/lib/libmosquitto.so.1 && \
+    install -s -m755 /build/mosq/build/src/mosquitto /usr/sbin/mosquitto && \
+    install -s -m755 /build/mosq/build/apps/mosquitto_ctrl/mosquitto_ctrl /usr/bin/mosquitto_ctrl && \
+    install -s -m755 /build/mosq/build/apps/mosquitto_passwd/mosquitto_passwd /usr/bin/mosquitto_passwd && \
+    install -s -m755 /build/mosq/build/apps/mosquitto_signal/mosquitto_signal /usr/bin/mosquitto_signal && \
+    install -s -m755 /build/mosq/build/plugins/acl-file/mosquitto_acl_file.so /usr/lib/mosquitto_acl_file.so && \
+    install -s -m755 /build/mosq/build/plugins/dynamic-security/mosquitto_dynamic_security.so /usr/lib/mosquitto_dynamic_security.so && \
+    install -s -m755 /build/mosq/build/plugins/password-file/mosquitto_password_file.so /usr/lib/mosquitto_password_file.so && \
+    install -s -m755 /build/mosq/build/plugins/persist-sqlite/mosquitto_persist_sqlite.so /usr/lib/mosquitto_persist_sqlite.so && \
+    install -s -m755 /build/mosq/build/plugins/sparkplug-aware/mosquitto_sparkplug_aware.so /usr/lib/mosquitto_sparkplug_aware.so && \
+    install -m644 /build/mosq/docker/2.1-alpine/mosquitto.conf /mosquitto/config/mosquitto.conf && \
+    install -m644 /build/mosq/docker/2.1-ubuntu/mosquitto.conf /mosquitto-no-auth.conf && \
+    install -d /usr/share/mosquitto && \
+    cp -r /build/mosq/dashboard/src /usr/share/mosquitto/dashboard && \
+    install -Dm644 /build/mosq/epl-v20 /usr/share/licenses/mosquitto/epl-v20 && \
+    install -Dm644 /build/mosq/edl-v10 /usr/share/licenses/mosquitto/edl-v10 && \
+    chown -R mosquitto:mosquitto /mosquitto && \
+    apk --no-cache add \
+        argon2-libs \
+        ca-certificates \
+        cjson \
+        libedit \
+        libmicrohttpd \
+        sqlite-libs \
+        tzdata && \
+    apk del build-deps && \
+    rm -rf /build
+
+VOLUME ["/mosquitto/data", "/mosquitto/log"]
+
+# Set up the entry point script and default command
+COPY --chmod=0755 docker-entrypoint.sh /
+EXPOSE 1883
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/usr/sbin/mosquitto", "-c", "/mosquitto/config/mosquitto.conf"]

--- a/docker/2.1-appuser/README.md
+++ b/docker/2.1-appuser/README.md
@@ -1,0 +1,104 @@
+# Eclipse Mosquitto Docker Image
+Containers built with this Dockerfile build as source from published tarballs.
+
+## Mount Points
+A docker mount point has been created in the image to be used for configuration.
+```
+/mosquitto/config
+```
+
+Two docker volumes have been created in the image to be used for persistent storage and logs.
+```
+/mosquitto/data
+/mosquitto/log
+```
+
+## User/Group
+
+The image runs mosquitto under the mosquitto user and group.
+Default uid and gid are 1883.
+
+- uid and gid can be specified at build time with `--build-arg UID={uid}` and`--build-arg GID={gid}`
+- uid and gid can be specified at runtime with `--env PUID={uid}` and `--env PGID={gid}`
+- changing of uid/gid will fail, if uid/gid already used
+
+The `docker-entrypoint.sh` script modifies
+group mosquitto's gid and user mosquitto's uid.
+Those will fail silently, if uid or gid is already occupied.
+The filesystem ownership will be changed, if group/user modification succeded.
+After modifications, the root privileges will be dropped
+and the process will be started under user account mosquitto.
+
+## Running without a configuration file
+Mosquitto 2.0 and up requires you to configure listeners and authentication
+before it will allow connections from anything other than the loopback
+interface. In the context of a container, this means you would normally need to
+provide a configuration file with your settings.
+
+However, this container provides a default configuration which listens on port
+1883 for unauthenticated access, and port 9883 for the local http dashboard.
+If you wish to run mosquitto without any authentication, and without setting
+any other configuration options, you can run without a configuration by binding
+the appropriate network ports:
+```
+docker run -it -p 1883:1883 -p localhost:9883:9883 eclipse-mosquitto:<version>
+```
+
+## Configuration
+To use a custom configuration file, create a **local** config directory with a
+mosquitto.conf inside, then mount this directory to `/mosquitto/config`
+
+```
+docker run -it -p 1883:1883 -v <absolute-path-to-config-directory>:/mosquitto/config eclipse-mosquitto:<version>
+```
+
+Your configuration file must include a `listener`, and you must configure some
+form of authentication or allow unauthenticated access. If you do not do this,
+clients will be unable to connect.
+
+
+File based authentication and authorisation:
+```
+listener 1883
+plugin /usr/lib/mosquitto_password_file.so
+plugin_opt_password_file /mosquitto/data/mosquitto.password_file
+
+plugin /usr/lib/mosquitto_acl_file.so
+plugin_opt_acl_file /mosquitto/data/mosquitto.aclfile
+```
+
+Plugin based authentication and authorisation:
+```
+listener 1883
+plugin /usr/lib/mosquitto_dynamic_security.so
+plugin_opt_config_file /mosquitto/data/mosquitto-dynsec.json
+```
+
+Unauthenticated access:
+```
+listener 1883
+allow_anonymous true
+```
+
+:boom: if the mosquitto configuration (mosquitto.conf) was modified
+to use non-default ports, the docker run command will need to be updated
+to expose the ports that have been configured, for example:
+
+```
+docker run -it -p 1883:1883 -p 8080:8080 -v <absolute-path-to-config-directory>:/mosquitto/config eclipse-mosquitto:<version>
+```
+
+Configuration can be changed to:
+
+* persist data to `/mosquitto/data`
+* log to `/mosquitto/log/mosquitto.log`
+
+i.e. add the following to `mosquitto.conf`:
+```
+persistence_location /mosquitto/data/
+plugin /usr/lib/mosquitto_persist_sqlite.so
+
+log_dest file /mosquitto/log/mosquitto.log
+```
+
+**Note**: For any volume used, the data will be persistent between containers.

--- a/docker/2.1-appuser/docker-entrypoint.sh
+++ b/docker/2.1-appuser/docker-entrypoint.sh
@@ -13,16 +13,15 @@ if [ "$(/usr/bin/id -u)" != '0' ]; then
 else
 	# change user and/or group to PUID/PGID
 	if [[ "${PGID}" != "${CURRENT_GID}" ]]; then
-		/usr/sbin/groupmod --gid "${PGID}" mosquitto 2>/dev/null && \
-		/bin/chgrp --recursive "${PGID}" /mosquitto 2>/dev/null || true
+		/usr/sbin/groupmod --gid "${PGID}" mosquitto 2>/dev/null || true
 	fi
 	if [[ "${PUID}" != "${CURRENT_UID}" ]]; then
 		# if modification of gid failed, the user's primary group will no longer be mosquitto
-		/usr/sbin/usermod --uid "${PUID}" --gid "${PGID}" --groups mosquitto mosquitto 2>/dev/null && \
-		/bin/chown --recursive "${PUID}" /mosquitto 2>/dev/null || true
+		/usr/sbin/usermod --uid "${PUID}" --gid "${PGID}" --groups mosquitto mosquitto 2>/dev/null || true
 	fi
 	# modify filesystem ownership, otherwise /mosquitto will be inaccessible (and mode=0750)
-	#[ -d "/mosquitto" ] && /bin/chown --recursive "${PUID}:${PGID}" /mosquitto 2>/dev/null || true
+	#/bin/chown --recursive "mosquitto:mosquitto" /mosquitto 2>/dev/null || true
+	/usr/bin/find /mosquitto -xdev -exec chown mosquitto:mosquitto {} \;
 fi
 
 # execute CMD

--- a/docker/2.1-appuser/docker-entrypoint.sh
+++ b/docker/2.1-appuser/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/ash
+### docker-entrypoint.sh for alpine linux
+set -e
+
+# get current uid/gid for user mosquitto
+CURRENT_UID=$(/usr/bin/id -u mosquitto)
+CURRENT_GID=$(/usr/bin/id -g mosquitto)
+
+# prepare user/group and permissions
+if [ "$(/usr/bin/id -u)" != '0' ]; then
+	# we are an unprivileged user, don't modify system
+	echo "running as: $(/usr/bin/id)"
+else
+	# change user and/or group to PUID/PGID
+	if [[ "${PGID}" != "${CURRENT_GID}" ]]; then
+		/usr/sbin/groupmod --gid "${PGID}" mosquitto 2>/dev/null && \
+		/bin/chgrp --recursive "${PGID}" /mosquitto 2>/dev/null || true
+	fi
+	if [[ "${PUID}" != "${CURRENT_UID}" ]]; then
+		# if modification of gid failed, the user's primary group will no longer be mosquitto
+		/usr/sbin/usermod --uid "${PUID}" --gid "${PGID}" --groups mosquitto mosquitto 2>/dev/null && \
+		/bin/chown --recursive "${PUID}" /mosquitto 2>/dev/null || true
+	fi
+	# modify filesystem ownership, otherwise /mosquitto will be inaccessible (and mode=0750)
+	#[ -d "/mosquitto" ] && /bin/chown --recursive "${PUID}:${PGID}" /mosquitto 2>/dev/null || true
+fi
+
+# execute CMD
+if [ "$(/usr/bin/id -u)" != '0' ]; then
+	# already running as unprivileged user
+	exec "$@"
+else
+	[ -x /usr/bin/setuidgid ] || apk --no-cache add daemontools-encore
+	# drop from root to mosquitto
+	/usr/bin/setuidgid mosquitto "$@"
+fi

--- a/docker/2.1-appuser/docker-entrypoint.sh
+++ b/docker/2.1-appuser/docker-entrypoint.sh
@@ -31,11 +31,4 @@ else
 fi
 
 # execute CMD
-if [ "$(/usr/bin/id -u)" != '0' ]; then
-	# already running as unprivileged user
-	exec "$@"
-else
-	[ -x /usr/bin/setuidgid ] || apk --no-cache add daemontools-encore
-	# drop from root to mosquitto
-	/usr/bin/setuidgid mosquitto "$@"
-fi
+exec "$@"

--- a/docker/2.1-appuser/docker-entrypoint.sh
+++ b/docker/2.1-appuser/docker-entrypoint.sh
@@ -13,11 +13,17 @@ if [ "$(/usr/bin/id -u)" != '0' ]; then
 else
 	# change user and/or group to PUID/PGID
 	if [[ "${PGID}" != "${CURRENT_GID}" ]]; then
-		/usr/sbin/groupmod --gid "${PGID}" mosquitto 2>/dev/null || true
+		/usr/sbin/groupmod --non-unique --gid "${PGID}" mosquitto 2>/dev/null || true
 	fi
 	if [[ "${PUID}" != "${CURRENT_UID}" ]]; then
-		# if modification of gid failed, the user's primary group will no longer be mosquitto
-		/usr/sbin/usermod --uid "${PUID}" --gid "${PGID}" --groups mosquitto mosquitto 2>/dev/null || true
+		# split to multiple usermod calls, ensure consistency
+		# modify uid
+		/usr/sbin/usermod --non-unique --uid "${PUID}" mosquitto || true
+		# modify primary group
+		/usr/sbin/usermod --gid "${PGID}" mosquitto || true
+		# modify additional group membership (this should be unneccessary, groupmod was called with --non-unique)
+		[[ "${PGID}" != "$(/bin/grep -e "^mosquitto:" /etc/group | /usr/bin/cut -d ":" -f3)" ]] && /usr/sbin/usermod --groups mosquitto mosquitto || true
+
 	fi
 	# modify filesystem ownership, otherwise /mosquitto will be inaccessible (and mode=0750)
 	#/bin/chown --recursive "mosquitto:mosquitto" /mosquitto 2>/dev/null || true


### PR DESCRIPTION
I am running eclipse-mosquitto in docker, using a modified image with **support for setting PUID/PGID**.

- The image is based on `2.1-alpine`.
- Package daemontools-encore provides needed setuidgid
- Package shadow provides needed groupmod and usermod
- docker-entrypoint.sh
  * modifies GID of group mosquitto
  * modifies UID and primary GID of user mosquitto
  * changes ownership of /mosquitto
  * starts configured `CMD` (rely on mosquitto dropping root privileges)
- fixes #2441 

For testing, the current image can be pulled from [Docker hub](https://hub.docker.com/repository/docker/marchefter/eclipse-mosquitto) image `marchefter/eclipse-mosquitto:appuser`.

```docker-compose.yml
services:
  mosquitto:
    image: marchefter/eclipse-mosquitto:appuser
    healthcheck:
      test: ["CMD-SHELL", "/usr/bin/mosquitto_sub -C 1 --topic '$$SYS/broker/uptime' 2>/dev/null || exit 1"]
    environment:
      TZ: "Europe/Berlin"
      PUID: 2388
      PGID: 1763
    ports:
      - "1883:1883" # default mqtt port
      - "8883:8883" # mqtt TLS port
    volumes:
      - ./mosquitto_config:/mosquitto/config
      - ./mosquitto_data:/mosquitto/data
      - ./mosquitto_log:/mosquitto/log
```
