### PR TITLE
Fix builtin websockets desync on fragmented frame headers

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -2,6 +2,10 @@
 ==================
 
 # Broker
+- Fix builtin websockets desynchronising and rejecting valid frames when a
+  frame header (extended payload length or masking key) was split across
+  multiple reads, e.g. due to TCP/TLS segmentation. Header parsing was
+  incorrectly gated on the payload length being zero.
 - Fix MOSQ_EVT_DISCONNECT being called before MOSQ_EVT_ACL_CHECK for the will
   of that client. Closes #3487.
 - Fix password length not being passed to MOSQ_EVT_BASIC_AUTH events.

--- a/lib/mosquitto_internal.h
+++ b/lib/mosquitto_internal.h
@@ -277,6 +277,7 @@ struct ws_data {
 	uint8_t mask_bytes;
 	uint8_t payloadlen_bytes;
 	bool is_client;
+	bool hdr_complete;
 };
 #endif
 

--- a/lib/net_ws.c
+++ b/lib/net_ws.c
@@ -230,7 +230,17 @@ ssize_t net__read_ws(struct mosquitto *mosq, void *buf, size_t count)
 {
 	ssize_t len = 0;
 
-	if(mosq->wsd.payloadlen == 0){
+	/* Parse the frame header. Each field (opcode, initial length byte,
+	 * extended length bytes, masking key) may arrive across multiple reads,
+	 * so we must be able to resume at the correct field on re-entry. The
+	 * header is only complete once all of them have been fully read.
+	 *
+	 * This must NOT be gated on `payloadlen == 0`: a payload length may
+	 * legitimately be zero, or may only have been partially read with its
+	 * already-received high-order bytes still zero. Gating on payloadlen
+	 * caused the remaining length bytes and/or the masking key to be skipped
+	 * when they were fragmented across reads, desynchronising the stream. */
+	if(!mosq->wsd.hdr_complete){
 		if(mosq->wsd.opcode == UINT8_MAX){
 			len = read_ws_opcode(mosq);
 			if(len <= 0){
@@ -250,6 +260,12 @@ ssize_t net__read_ws(struct mosquitto *mosq, void *buf, size_t count)
 			if(len <= 0){
 				return len;
 			}
+			if(mosq->wsd.payloadlen_bytes > 0){
+				/* Extended length only partially read - wait for the
+				 * remaining bytes before reading the masking key. */
+				errno = EAGAIN;
+				return -1;
+			}
 		}
 
 		if(mosq->wsd.mask == 1 && mosq->wsd.mask_bytes > 0){
@@ -258,6 +274,8 @@ ssize_t net__read_ws(struct mosquitto *mosq, void *buf, size_t count)
 				return len;
 			}
 		}
+
+		mosq->wsd.hdr_complete = true;
 
 		if(mosq->wsd.opcode == WS_CLOSE && mosq->wsd.payloadlen == 1){
 			mosq->wsd.disconnect_reason = 0xEA;
@@ -336,6 +354,7 @@ ssize_t net__read_ws(struct mosquitto *mosq, void *buf, size_t count)
 		mosq->wsd.payloadlen = 0;
 		mosq->wsd.opcode = UINT8_MAX;
 		mosq->wsd.mask = UINT8_MAX;
+		mosq->wsd.hdr_complete = false;
 	}else if(mosq->wsd.out_packet){
 		/* Testing or PING - so we haven't read any data for the application yet.
 		* Simulate that situation.*/

--- a/test/broker/13-websocket-fragmented-frame.py
+++ b/test/broker/13-websocket-fragmented-frame.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+# Test whether the broker correctly reassembles a websocket frame whose header
+# (extended payload length and masking key) is split across multiple TCP
+# segments. Regression test for a desync in net__read_ws() where header parsing
+# was gated on the payload length being zero, causing the remaining length
+# bytes and/or masking key to be skipped when fragmented - leaving the stream
+# out of sync and rejecting a perfectly valid CONNECT.
+
+from mosq_test_helper import *
+
+from broker_config import BrokerConfig, ListenerConfig
+from mosquitto_broker import MosquittoBroker
+
+mosq_test.require_features(["WITH_WEBSOCKETS", "WITH_WEBSOCKETS_BUILTIN"])
+
+# Long client id so the CONNECT exceeds 125 bytes and a 2-byte extended
+# websocket length is used - that length field is what we fragment.
+client_id = "frag-" + "A"*200
+connect_packet = mqtt_packets.gen_connect(client_id, keepalive=60, proto_ver=4)
+connack_packet = mqtt_packets.gen_connack(rc=0, proto_ver=4)
+
+port = mosq_test.get_port()
+broker_config = BrokerConfig(
+    listeners=[
+        ListenerConfig(
+            port=port,
+            protocol="websockets",
+        )
+    ],
+    allow_anonymous=True,
+    log_type="all",
+)
+
+websocket_req_good = b"GET /mqtt HTTP/1.1\r\n" \
+    + b"Host: localhost\r\n" \
+    + b"Upgrade: websocket\r\n" \
+    + b"Connection: Upgrade\r\n" \
+    + B"Sec-WebSocket-Key: 1JaITHdgDZVd/4OE2AzTTA==\r\n" \
+    + b"Sec-WebSocket-Protocol: mqtt\r\n" \
+    + b"Sec-WebSocket-Version: 13\r\n" \
+    + b"Origin: example.org\r\n" \
+    + b"\r\n"
+
+websocket_resp_good = b"HTTP/1.1 101 Switching Protocols\r\n" \
+    + b"Upgrade: WebSocket\r\n" \
+    + b"Connection: Upgrade\r\n" \
+    + b"Sec-WebSocket-Accept: Ako91O0lxiq8gN0+b9YCijMx8lk=\r\n" \
+    + b"Sec-WebSocket-Protocol: mqtt\r\n" \
+    + b"\r\n"
+
+# Masked binary frame carrying the CONNECT, with a 2-byte extended length.
+length = len(connect_packet)
+mask_key = bytearray(os.urandom(4))
+connect_frame = bytearray()
+connect_frame.append(0x82)              # FIN + binary
+connect_frame.append(0x80 | 126)        # mask bit + 126 => 2-byte length follows
+connect_frame += length.to_bytes(2, "big")
+connect_frame += mask_key
+for i in range(length):
+    connect_frame.append(connect_packet[i] ^ mask_key[i % 4])
+
+connack_frame = bytearray()
+connack_frame.append(0x82)
+connack_frame.append(len(connack_packet))
+connack_frame += connack_packet
+connack_frame = bytes(connack_frame)
+
+broker = MosquittoBroker(config=broker_config)
+with broker:
+    sock = mosq_test.do_client_connect(websocket_req_good, websocket_resp_good, port=port)
+
+    # Send the CONNECT frame fragmented on the length/mask boundaries:
+    #   [0:2]  opcode + length-flag byte
+    #   [2:3]  first extended-length byte
+    #   [3:6]  second length byte + first 2 mask bytes
+    #   [6:]   remaining mask bytes + masked payload
+    frame = bytes(connect_frame)
+    for seg in (frame[0:2], frame[2:3], frame[3:6], frame[6:]):
+        sock.send(seg)
+        time.sleep(0.05)
+
+    mosq_test.expect_packet(sock, "connack", connack_frame)
+    sock.close()
+
+print("Test passed")

--- a/test/broker/test.py
+++ b/test/broker/test.py
@@ -206,6 +206,7 @@ tests = [
     (1, './12-prop-server-keepalive.py'),
 
     (1, './13-websocket-bad-origin.py'),
+    (1, './13-websocket-fragmented-frame.py'),
 
     (1, './14-dynsec-acl.py'),
     (1, './14-dynsec-allow-wildcard.py'),


### PR DESCRIPTION
## Fix builtin websockets desync on fragmented frame headers

### Summary
`net__read_ws()` (builtin websockets, 2.1+) gates all frame-header parsing on
`mosq->wsd.payloadlen == 0`. When a websocket frame header is delivered across
more than one read — normal under TCP/TLS segmentation, and trivially forced by
a client — this desynchronises the stream and rejects valid frames.

### Two failure modes
1. **Split extended length.** After a partial read of the 2/8-byte extended
   payload length whose received high bytes are still `0x00`, `payloadlen`
   stays `0`, so the code falls through and reads the *masking key* out of what
   are still length bytes. It then returns a positive count **without writing
   the caller's buffer**, feeding uninitialised heap bytes into the MQTT parser.
2. **Split masking key.** Once `payloadlen` is non-zero the header block is
   skipped on re-entry, so a masking key split across reads is never completed
   and the payload is unmasked with a half-populated key.

Both desync the stream; a valid CONNECT is misread (`First packet not CONNECT`)
and the connection is dropped. Bounds are respected, so this is not memory
corruption — impact is failed/dropped connections (DoS / interop) plus use of
uninitialised bytes as packet content.

### Fix
Track header completion explicitly (`wsd.hdr_complete`) instead of inferring it
from `payloadlen`, and return `EAGAIN` after a partial extended-length read so
the remaining length bytes are consumed before the masking key.

### Test
`test/broker/14-websocket-fragmented-frame.py` fragments a CONNECT frame on the
length/mask boundaries and asserts CONNACK. It fails before the fix
(`First packet not CONNECT`, connection reset) and passes after.

Verified: `make WITH_WEBSOCKETS=yes` builds clean under
`-Wall -Wextra -Wconversion -Werror`; normal `ws://` pub/sub unaffected.
