### PR TITLE
Broker: avoid EPOLLOUT add/remove churn per write (+60-90% throughput)

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -2,6 +2,10 @@
 ==================
 
 # Broker
+- Improve outgoing message throughput by no longer registering and immediately
+  deregistering EPOLLOUT for every write. The socket is only added to the write
+  set when a write actually blocks, removing two epoll_ctl() syscalls per write
+  in the common case where the socket accepts the data straight away.
 - Fix MOSQ_EVT_DISCONNECT being called before MOSQ_EVT_ACL_CHECK for the will
   of that client. Closes #3487.
 - Fix password length not being passed to MOSQ_EVT_BASIC_AUTH events.

--- a/lib/packet_mosq.c
+++ b/lib/packet_mosq.c
@@ -290,12 +290,13 @@ int packet__write(struct mosquitto *mosq)
 		return MOSQ_ERR_SUCCESS;
 	}
 
-#ifdef WITH_BROKER
-	mux__add_out(mosq);
-#endif
-
 	state = mosquitto__get_state(mosq);
 	if(state == mosq_cs_connect_pending){
+#ifdef WITH_BROKER
+		/* Outgoing connection still in progress - ask the event loop to
+		 * notify us when the socket becomes writable (== connected). */
+		mux__add_out(mosq);
+#endif
 		return MOSQ_ERR_SUCCESS;
 	}
 
@@ -313,6 +314,13 @@ int packet__write(struct mosquitto *mosq)
 						|| errno == WSAENOTCONN
 #endif
 						){
+#ifdef WITH_BROKER
+					/* Socket buffer full - only now do we need the event
+					 * loop to tell us when it is writable again. In the
+					 * common case where the write completes synchronously
+					 * this avoids two epoll_ctl() calls per write. */
+					mux__add_out(mosq);
+#endif
 					return MOSQ_ERR_SUCCESS;
 				}else{
 					switch(errno){

--- a/misc/bench/README.md
+++ b/misc/bench/README.md
@@ -1,0 +1,49 @@
+# Broker throughput benchmark
+
+A small harness for measuring broker message throughput, used to substantiate
+performance changes such as the EPOLLOUT-toggle removal in `packet__write()`.
+
+## Contents
+- `mqtt_throughput_pub.c` — single-connection QoS-0 publisher that reports the
+  achieved publish rate.
+- `multibench.sh` — drives `M` publishers and `N` subscribers on one topic and
+  reports aggregate ingress rate.
+
+## Build
+```
+cc -O2 mqtt_throughput_pub.c -lmosquitto -o mqtt_throughput_pub
+```
+
+## Single publisher / single subscriber
+```
+mosquitto -c broker.conf &                 # listener on 1883, allow_anonymous
+mosquitto_sub -t bench/topic -q 0 -C 3000000 >/dev/null &
+./mqtt_throughput_pub 1883 3000000 64 bench/topic
+```
+
+## Multiple publishers / subscribers
+```
+./multibench.sh /path/to/mosquitto 4 4 200000 64   # 4 pub, 4 sub, 200k each
+```
+
+## Measuring a change correctly
+Absolute throughput on virtualised / shared hosts drifts significantly between
+runs, so an A/B comparison must control for it:
+
+1. Build **two named binaries** from the two revisions and confirm they differ
+   (`md5sum`). Do not rely on `git stash` + `make`: on a branch where the change
+   is already committed the stash is a no-op, and `make` may skip recompiling on
+   a stale object timestamp — yielding two identical binaries.
+2. **Interleave** trials (baseline, patched, baseline, patched, …) rather than
+   running all of one then all of the other, so host drift affects both equally.
+3. Prefer a **deterministic** signal where possible. For the EPOLLOUT change,
+   `strace -c -e epoll_ctl` on the broker over a fixed message count is immune to
+   timing noise:
+
+   | build    | epoll_ctl / 200k msgs |
+   |----------|-----------------------|
+   | before   | ~334,000 (~1.67/msg)  |
+   | after    | ~0                    |
+
+Pin the broker to a dedicated core (`taskset -c`) to reduce scheduler noise;
+the broker runs a single event-loop thread, so this measures per-core capacity.

--- a/misc/bench/mqtt_throughput_pub.c
+++ b/misc/bench/mqtt_throughput_pub.c
@@ -1,0 +1,78 @@
+/*
+Copyright (c) 2026 the Mosquitto contributors.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License 2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+SPDX-License-Identifier: EPL-2.0 OR EDL-1.0
+*/
+
+/*
+ * Minimal single-connection throughput publisher for the broker.
+ *
+ * Opens one connection, publishes N QoS-0 messages of a fixed size as fast as
+ * the broker will accept them, then reports the achieved rate. Used together
+ * with one or more `mosquitto_sub` consumers to measure broker routing and
+ * write throughput.
+ *
+ * Build:  cc -O2 mqtt_throughput_pub.c -lmosquitto -o mqtt_throughput_pub
+ * Usage:  mqtt_throughput_pub [port] [count] [payload_bytes] [topic]
+ */
+
+#include <mosquitto.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+int main(int argc, char **argv)
+{
+	const char *host = "127.0.0.1";
+	int port  = argc > 1 ? atoi(argv[1]) : 1883;
+	long n    = argc > 2 ? atol(argv[2]) : 1000000;
+	int psize = argc > 3 ? atoi(argv[3]) : 64;
+	const char *topic = argc > 4 ? argv[4] : "bench/topic";
+	struct timespec t0, t1;
+	struct mosquitto *m;
+	char *payload;
+	double dt;
+
+	payload = malloc((size_t)psize);
+	if(!payload){ return 1; }
+	memset(payload, 'x', (size_t)psize);
+
+	mosquitto_lib_init();
+	m = mosquitto_new(NULL, true, NULL);
+	if(!m || mosquitto_connect(m, host, port, 60)){
+		fprintf(stderr, "connect to %s:%d failed\n", host, port);
+		return 1;
+	}
+
+	clock_gettime(CLOCK_MONOTONIC, &t0);
+	for(long i=0; i<n; i++){
+		int rc = mosquitto_publish(m, NULL, topic, psize, payload, 0, false);
+		if(rc == MOSQ_ERR_NOMEM || rc == MOSQ_ERR_ERRNO){
+			mosquitto_loop_write(m, 1);
+			i--;
+			continue;
+		}
+		if((i & 0x3FF) == 0){
+			mosquitto_loop_write(m, 1); /* drain periodically */
+		}
+	}
+	while(mosquitto_want_write(m)){
+		mosquitto_loop_write(m, 1);
+	}
+	clock_gettime(CLOCK_MONOTONIC, &t1);
+
+	dt = (double)(t1.tv_sec - t0.tv_sec) + (double)(t1.tv_nsec - t0.tv_nsec)/1e9;
+	fprintf(stderr, "published %ld msgs (%dB) in %.3fs = %.0f msg/s (%.1f MB/s)\n",
+			n, psize, dt, (double)n/dt, (double)n*(double)psize/1e6/dt);
+
+	mosquitto_disconnect(m);
+	mosquitto_destroy(m);
+	mosquitto_lib_cleanup();
+	free(payload);
+	return 0;
+}

--- a/misc/bench/multibench.sh
+++ b/misc/bench/multibench.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Aggregate throughput with M publishers and N subscribers on one topic.
+#
+# Usage: multibench.sh BROKER_BIN [M] [N] [PER] [SIZE]
+#   BROKER_BIN  path to the mosquitto broker to test
+#   M           number of publishers (default 4)
+#   N           number of subscribers (default 4)
+#   PER         messages per publisher (default 200000)
+#   SIZE        payload bytes (default 64)
+#
+# The broker is pinned to one core (single event-loop thread => per-core
+# capacity). Timing covers the parallel publisher burst; each publisher drains
+# to the broker before exiting, and the broker throttles via TCP backpressure,
+# so wall time reflects ingest+route+deliver capacity. Prints ingress msg/s.
+#
+# To compare two builds, run this alternately against two named binaries and
+# average; do not run all of one then all of the other (see README.md).
+set -u
+BIN=${1:?usage: multibench.sh BROKER_BIN [M] [N] [PER] [SIZE]}
+M=${2:-4}; N=${3:-4}; PER=${4:-200000}; SIZE=${5:-64}
+HERE=$(cd "$(dirname "$0")" && pwd)
+PUB="$HERE/mqtt_throughput_pub"
+PORT=1888; TOPIC=bench/topic; TOTAL=$((M*PER))
+CONF=$(mktemp); printf 'listener %d\nallow_anonymous true\nmax_queued_messages 1000000\n' "$PORT" >"$CONF"
+
+taskset -c 2 "$BIN" -c "$CONF" >/dev/null 2>&1 &
+BPID=$!; sleep 0.8
+spids=()
+for i in $(seq 0 $((N-1))); do
+	mosquitto_sub -p $PORT -t "$TOPIC" -q 0 >/dev/null 2>&1 &
+	spids+=($!)
+done
+sleep 1.2
+ppids=()
+t0=$(date +%s.%N)
+for i in $(seq 0 $((M-1))); do
+	"$PUB" $PORT "$PER" "$SIZE" "$TOPIC" >/dev/null 2>&1 &
+	ppids+=($!)
+done
+for p in "${ppids[@]}"; do wait "$p"; done
+t1=$(date +%s.%N)
+for p in "${spids[@]}"; do kill "$p" 2>/dev/null; done
+kill $BPID 2>/dev/null; wait 2>/dev/null
+rm -f "$CONF"
+awk "BEGIN{printf \"M=%d N=%d %dx%dB: %.0f ingress msg/s\n\",$M,$N,$PER,$SIZE,$TOTAL/($t1-$t0)}"


### PR DESCRIPTION
## Broker: avoid EPOLLOUT add/remove churn on every write

### Summary
`packet__write()` (broker build) registers EPOLLOUT via `mux__add_out()` at the
top of the function and removes it again via `mux__remove_out()` once the out
queue drains. In the common case — the socket accepts the write synchronously —
this costs **two `epoll_ctl()` syscalls per write cycle that the event loop
never needed**.

This changes it to the standard level-triggered pattern: only register EPOLLOUT
when a write actually blocks (`EAGAIN` with data still pending). The outgoing
bridge `connect_pending` case still arms EPOLLOUT explicitly, and `packet__queue`
already attempts an eager write for every queued packet, so nothing can be left
waiting for an EPOLLOUT that was never armed.

### Deterministic effect (`strace -c -e epoll_ctl`, fixed 200k-message run)
| build    | epoll_ctl calls | per message |
|----------|-----------------|-------------|
| before   | 334,728         | ~1.67       |
| after    | 2               | ~0          |

`perf` before: `epoll_ctl` = ~9.6% of broker CPU; after: absent from the profile.

### Throughput (interleaved A/B, broker pinned to one core, plain TCP, 64B QoS0)
| scenario        | before   | after    | delta |
|-----------------|----------|----------|-------|
| 1 pub → 1 sub   | 304k/s   | 547k/s   | +80%  |
| 8 pub → 2 sub   | 129k/s   | 249k/s   | +93%  |
| 4 pub → 4 sub   |  50k/s   |  86k/s   | +72%  |
| 2 pub → 8 sub   |  24k/s   |  39k/s   | +64%  |
| 8 pub → 8 sub   |  36k/s   |  58k/s   | +60%  |

(Trials alternated between two fixed binaries built from the parent commit and
this commit, to control for host drift.)

### Correctness
- Backpressure — 100 KB QoS1 messages to a deliberately slow reader, all
  delivered intact and in order over **plain TCP, TLS (SSL_write WANT_WRITE),
  and builtin WebSockets**.
- Fan-out 1→40 subscribers: every subscriber received all messages, no
  corruption.
- `poll` backend (`WITH_EPOLL=no`) exercised as well as epoll.
- No busy-loop: broker CPU stays low while backpressured.
- Broker test suite: unchanged pass/fail versus the parent commit (including the
  bridge tests that cover the `connect_pending` path).

### Second commit (optional)
The second commit adds a small throughput benchmark under `misc/bench/` used to
produce the numbers above. Happy to drop it if you'd rather keep it out of tree.
