### PR TITLE
Fix builtin websockets dropping the session on an empty data frame

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -12,6 +12,9 @@
   Closes #3515.
 - Fix will messages being incorrectly delayed if a client set
   session-expiry-interval=0 when using will-delay-interval>0. Closes #3505.
+- Fix builtin websockets treating a data frame with an empty payload as a
+  framing error, which desynchronised the MQTT stream and dropped the
+  session. Closes #3704.
 
 # Common lib:
 - Fix potential crash if reading a file in restricted mode and the group id

--- a/lib/net_ws.c
+++ b/lib/net_ws.c
@@ -332,6 +332,15 @@ ssize_t net__read_ws(struct mosquitto *mosq, void *buf, size_t count)
 			* packet__queue. */
 			len = -1;
 			errno = EAGAIN;
+		}else if(mosq->wsd.payloadlen == 0){
+			/* A data frame with no payload. This is valid - a frame carries a
+			* piece of the MQTT byte stream and is allowed to carry none of it -
+			* but no application data has been produced. Without this, `len`
+			* still holds the size of the last header field read, and returning
+			* it tells the caller that many bytes of MQTT data are waiting in a
+			* buffer nothing was written to. */
+			len = -1;
+			errno = EAGAIN;
 		}
 		mosq->wsd.payloadlen = 0;
 		mosq->wsd.opcode = UINT8_MAX;

--- a/test/broker/13-websocket-empty-frame.py
+++ b/test/broker/13-websocket-empty-frame.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+
+# Test whether the broker keeps an MQTT session intact when a client sends a
+# websocket data frame with an empty payload. Such a frame is valid - RFC 6455
+# permits a zero-length payload, and MQTT treats websocket framing as a
+# transparent carrier for the MQTT byte stream, so a frame contributing no
+# bytes must simply be consumed - but net__read_ws() returned a positive byte
+# count for it without writing anything to the caller's buffer. The MQTT parser
+# then treated that many stale buffer bytes as packet data, desynchronising the
+# stream: the session stopped responding and was dropped.
+
+from mosq_test_helper import *
+
+from broker_config import BrokerConfig, ListenerConfig
+from mosquitto_broker import MosquittoBroker
+
+mosq_test.require_features(["WITH_WEBSOCKETS", "WITH_WEBSOCKETS_BUILTIN"])
+
+port = mosq_test.get_port()
+broker_config = BrokerConfig(
+    listeners=[
+        ListenerConfig(
+            port=port,
+            protocol="websockets",
+        )
+    ],
+    allow_anonymous=True,
+    log_type="all",
+)
+
+websocket_req = b"GET /mqtt HTTP/1.1\r\n" \
+    + b"Host: localhost\r\n" \
+    + b"Upgrade: websocket\r\n" \
+    + b"Connection: Upgrade\r\n" \
+    + B"Sec-WebSocket-Key: 1JaITHdgDZVd/4OE2AzTTA==\r\n" \
+    + b"Sec-WebSocket-Protocol: mqtt\r\n" \
+    + b"Sec-WebSocket-Version: 13\r\n" \
+    + b"\r\n"
+
+websocket_resp = b"HTTP/1.1 101 Switching Protocols\r\n" \
+    + b"Upgrade: WebSocket\r\n" \
+    + b"Connection: Upgrade\r\n" \
+    + b"Sec-WebSocket-Accept: Ako91O0lxiq8gN0+b9YCijMx8lk=\r\n" \
+    + b"Sec-WebSocket-Protocol: mqtt\r\n" \
+    + b"\r\n"
+
+
+def client_frame(payload):
+    """A masked binary frame, as a client must send."""
+    mask_key = bytearray(os.urandom(4))
+    frame = bytearray()
+    frame.append(0x82)                      # FIN + binary
+    length = len(payload)
+    if length < 126:
+        frame.append(0x80 | length)         # mask bit + length
+    else:
+        frame.append(0x80 | 126)
+        frame += length.to_bytes(2, "big")
+    frame += mask_key
+    for i in range(length):
+        frame.append(payload[i] ^ mask_key[i % 4])
+    return bytes(frame)
+
+
+def server_frame(payload):
+    """A frame as the broker sends it: binary, unmasked."""
+    frame = bytearray()
+    frame.append(0x82)
+    frame.append(len(payload))
+    frame += payload
+    return bytes(frame)
+
+
+connack_frame = server_frame(mqtt_packets.gen_connack(rc=0, proto_ver=4))
+pingresp_frame = server_frame(mqtt_packets.gen_pingresp())
+suback_frame = server_frame(mqtt_packets.gen_suback(mid=1, qos=0, proto_ver=4))
+
+broker = MosquittoBroker(config=broker_config)
+with broker:
+    # An empty frame before anything else: the CONNECT that follows it must
+    # still be read as a CONNECT.
+    sock = mosq_test.do_client_connect(websocket_req, websocket_resp, port=port)
+    sock.send(client_frame(b""))
+    sock.send(client_frame(mqtt_packets.gen_connect("empty-frame-first", keepalive=60, proto_ver=4)))
+    mosq_test.expect_packet(sock, "connack", connack_frame)
+    sock.close()
+
+    # An empty frame in the middle of an established session: what follows must
+    # still be understood, and the session must survive.
+    sock = mosq_test.do_client_connect(websocket_req, websocket_resp, port=port)
+    sock.send(client_frame(mqtt_packets.gen_connect("empty-frame-mid", keepalive=60, proto_ver=4)))
+    mosq_test.expect_packet(sock, "connack", connack_frame)
+
+    sock.send(client_frame(b""))
+    sock.send(client_frame(mqtt_packets.gen_pingreq()))
+    mosq_test.expect_packet(sock, "pingresp", pingresp_frame)
+
+    # And again before a packet with a payload of its own, so that the check is
+    # not specific to a two-byte one.
+    sock.send(client_frame(b""))
+    sock.send(client_frame(mqtt_packets.gen_subscribe(mid=1, topic="empty/frame", qos=0, proto_ver=4)))
+    mosq_test.expect_packet(sock, "suback", suback_frame)
+    sock.close()
+
+    # Several empty frames in a row, since each one is consumed separately.
+    sock = mosq_test.do_client_connect(websocket_req, websocket_resp, port=port)
+    for _ in range(5):
+        sock.send(client_frame(b""))
+    sock.send(client_frame(mqtt_packets.gen_connect("empty-frames-many", keepalive=60, proto_ver=4)))
+    mosq_test.expect_packet(sock, "connack", connack_frame)
+    sock.close()
+
+print("Test passed")

--- a/test/broker/test.py
+++ b/test/broker/test.py
@@ -206,6 +206,7 @@ tests = [
     (1, './12-prop-server-keepalive.py'),
 
     (1, './13-websocket-bad-origin.py'),
+    (1, './13-websocket-empty-frame.py'),
 
     (1, './14-dynsec-acl.py'),
     (1, './14-dynsec-allow-wildcard.py'),


### PR DESCRIPTION
Fixes #3704.

### The defect

`net__read_ws()` returns the number of bytes of MQTT data it has placed in the caller's buffer. For a data frame with an **empty payload** it writes nothing, but still returns a positive count: `len` holds the size of the last frame header field read, `if(mosq->wsd.payloadlen > 0)` does nothing, and in the completion block none of the branches (`WS_CLOSE`, `WS_PONG`, `out_packet`) apply to a zero-length `WS_BINARY` / `WS_CONTINUATION` frame, so that value is returned unchanged.

The MQTT parser then treats that many bytes of whatever the buffer already held as packet data. The stream is desynchronised from that point on: the session stops responding, and the stale bytes are re-parsed as if they were a new control packet.

An empty data frame is valid. RFC 6455 §5.2 permits a zero-length payload, and MQTT treats the WebSocket framing as a transparent carrier for its byte stream — a frame contributing no bytes must be consumed and awaited, not turned into a framing error.

### Who emits one

`paho.golang` does, in the middle of a `SUBSCRIBE`: it turns each write into a frame, and the empty property section becomes a zero-length frame. An MQTT 5 client connecting to 2.1 over WebSockets therefore connects, subscribes to nothing, and receives nothing, while reporting a healthy connection. That is how this was found. Every other framing shape tested behaves correctly on 2.1 — one frame per packet, a packet split across two frames, one byte per frame — and 2.0.x accepts the empty frame as well, so this is specific to the builtin backend introduced in 2.1.

### The fix

Report "no application data yet" for such a frame — `EAGAIN`, which is what this function already does for `PING` and `CLOSE` — so the caller waits for the next frame. Nine lines, in the completion block.

Only the builtin backend is affected; `libwebsockets` is a different code path.

### Test

`test/broker/13-websocket-empty-frame.py` covers an empty frame before the `CONNECT`, in the middle of an established session before a `PINGREQ` and before a `SUBSCRIBE`, and five in a row. It fails without the fix (`BrokenPipeError: when reading connack`) and passes with it.

### Verified

- `make WITH_WEBSOCKETS=yes` clean under `-Wall -Wextra -Wconversion -Werror`.
- The reproducer from #3704 against builds of this branch: `PINGRESP` arrives; without the fix the session is dead.
- `13-websocket-bad-origin.py`, `21-proxy-v2-websockets.py` and the `01-connect-*` tests still pass.

### Relationship to #3721

Both touch `net__read_ws()` and they are independent defects — #3721 is about a frame header split across reads, this one about a frame with no payload. A build of the #3721 branch alone still fails the reproducer here, and vice versa; with both applied, both regression tests pass.

`lib/net_ws.c` and `ChangeLog.txt` merge cleanly in either order. The one overlap is `test/broker/test.py`: both add a line to the websockets group, so whichever of the two is merged second needs that one line resolving. I would rather leave it than move either entry out of alphabetical order, and I will rebase this branch as soon as the other is merged.
