### PR TITLE
Fix ACL substitutions containing hierarchy separators

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -2,6 +2,8 @@
 ==================
 
 # Broker
+- Fix `%c` and `%u` ACL substitutions not matching client ids or usernames
+  containing `/`. Closes #3520.
 - Fix MOSQ_EVT_DISCONNECT being called before MOSQ_EVT_ACL_CHECK for the will
   of that client. Closes #3487.
 - Fix password length not being passed to MOSQ_EVT_BASIC_AUTH events.

--- a/libcommon/topic_common.c
+++ b/libcommon/topic_common.c
@@ -208,10 +208,13 @@ static int topic_matches_sub(const char *sub, const char *topic, const char *cli
 			if(pattern_check == NULL || pattern_check[0] == '\0'){
 				return MOSQ_ERR_SUCCESS;
 			}
+			if(strpbrk(pattern_check, "+#") != NULL){
+				return MOSQ_ERR_SUCCESS;
+			}
 			spos += 2;
 			sub += 2;
 
-			while(pattern_check[0] != 0 && topic[0] != 0 && topic[0] != '/'){
+			while(pattern_check[0] != 0 && topic[0] != 0){
 				if(pattern_check[0] != topic[0]){
 					/* Valid input, but no match */
 					return MOSQ_ERR_SUCCESS;
@@ -374,21 +377,14 @@ static int sub_matches_acl(const char *acl, const char *sub, const char *clienti
 				/* no match */
 				return MOSQ_ERR_SUCCESS;
 			}
-			if(pattern_check[1] == '\0' &&
-					(
-						pattern_check[0] == '+' ||
-						pattern_check[0] == '#' ||
-						pattern_check[0] == '/')
-					){
-
-				/* username/client id of just + / # not allowed */
+			if(strpbrk(pattern_check, "+#") != NULL){
 				return MOSQ_ERR_SUCCESS;
 			}
 
 			apos +=2;
 			acl += 2;
 
-			while(pattern_check[0] != 0 && sub[0] != 0 && sub[0] != '/'){
+			while(pattern_check[0] != 0 && sub[0] != 0){
 				if(pattern_check[0] != sub[0]){
 					/* Valid input, but no match */
 					return MOSQ_ERR_SUCCESS;

--- a/test/unit/libcommon/topic_test.c
+++ b/test/unit/libcommon/topic_test.c
@@ -561,21 +561,29 @@ static void TEST_topic_pattern_wildcard(void)
 	int rc;
 	bool match;
 
+	/* Topic hierarchy in client id */
+	rc = mosquitto_topic_matches_sub_with_pattern("%c", "clientid/test", "clientid/test", NULL, &match);
+	CU_ASSERT_EQUAL(rc, MOSQ_ERR_SUCCESS);
+	CU_ASSERT_EQUAL(match, true);
+
+	/* Topic hierarchy in username */
+	rc = mosquitto_topic_matches_sub_with_pattern("%u", "username/test", NULL, "username/test", &match);
+	CU_ASSERT_EQUAL(rc, MOSQ_ERR_SUCCESS);
+	CU_ASSERT_EQUAL(match, true);
+
+	rc = mosquitto_topic_matches_sub_with_pattern("%u/#", "user/name/topic", NULL, "user/name", &match);
+	CU_ASSERT_EQUAL(rc, MOSQ_ERR_SUCCESS);
+	CU_ASSERT_EQUAL(match, true);
+
 	/* Malicious */
 	/* ========= */
 
-	/* / in client id */
-	rc = mosquitto_topic_matches_sub_with_pattern("%c", "clientid/test", "clientid/test", NULL, &match);
-	CU_ASSERT_EQUAL(rc, MOSQ_ERR_SUCCESS);
-	CU_ASSERT_EQUAL(match, false);
-
-	/* / in username */
-	rc = mosquitto_topic_matches_sub_with_pattern("%u", "username/test", NULL, "username/test", &match);
-	CU_ASSERT_EQUAL(rc, MOSQ_ERR_SUCCESS);
-	CU_ASSERT_EQUAL(match, false);
-
 	/* + in client id */
 	rc = mosquitto_topic_matches_sub_with_pattern("%c", "clientid", "+", NULL, &match);
+	CU_ASSERT_EQUAL(rc, MOSQ_ERR_SUCCESS);
+	CU_ASSERT_EQUAL(match, false);
+
+	rc = mosquitto_topic_matches_sub_with_pattern("%c/#", "client+id/topic", "client+id", NULL, &match);
 	CU_ASSERT_EQUAL(rc, MOSQ_ERR_SUCCESS);
 	CU_ASSERT_EQUAL(match, false);
 
@@ -1065,26 +1073,30 @@ static void TEST_acl_pattern_wildcard(void)
 	int rc;
 	bool match;
 
-	/* Malicious */
-	/* ========= */
-
-	/* / in client id */
+	/* Topic hierarchy in client id */
 	rc = mosquitto_sub_matches_acl_with_pattern("%c", "clientid/test", "clientid/test", NULL, &match);
 	CU_ASSERT_EQUAL(rc, MOSQ_ERR_SUCCESS);
-	CU_ASSERT_EQUAL(match, false);
+	CU_ASSERT_EQUAL(match, true);
+
+	rc = mosquitto_sub_matches_acl_with_pattern("%c/#", "client/id/topic", "client/id", NULL, &match);
+	CU_ASSERT_EQUAL(rc, MOSQ_ERR_SUCCESS);
+	CU_ASSERT_EQUAL(match, true);
 
 	rc = mosquitto_sub_matches_acl_with_pattern("%c", "/", "/", NULL, &match);
 	CU_ASSERT_EQUAL(rc, MOSQ_ERR_SUCCESS);
-	CU_ASSERT_EQUAL(match, false);
+	CU_ASSERT_EQUAL(match, true);
 
-	/* / in username */
+	/* Topic hierarchy in username */
 	rc = mosquitto_sub_matches_acl_with_pattern("%u", "username/test", NULL, "username/test", &match);
 	CU_ASSERT_EQUAL(rc, MOSQ_ERR_SUCCESS);
-	CU_ASSERT_EQUAL(match, false);
+	CU_ASSERT_EQUAL(match, true);
 
 	rc = mosquitto_sub_matches_acl_with_pattern("%u", "/", NULL, "/", &match);
 	CU_ASSERT_EQUAL(rc, MOSQ_ERR_SUCCESS);
-	CU_ASSERT_EQUAL(match, false);
+	CU_ASSERT_EQUAL(match, true);
+
+	/* Malicious */
+	/* ========= */
 
 	/* + in client id */
 	rc = mosquitto_sub_matches_acl_with_pattern("%c", "clientid", "+", NULL, &match);
@@ -1115,6 +1127,10 @@ static void TEST_acl_pattern_wildcard(void)
 
 	/* # in username */
 	rc = mosquitto_sub_matches_acl_with_pattern("%u", "#", NULL, "#", &match);
+	CU_ASSERT_EQUAL(rc, MOSQ_ERR_SUCCESS);
+	CU_ASSERT_EQUAL(match, false);
+
+	rc = mosquitto_sub_matches_acl_with_pattern("%u/#", "user#name/topic", NULL, "user#name", &match);
 	CU_ASSERT_EQUAL(rc, MOSQ_ERR_SUCCESS);
 	CU_ASSERT_EQUAL(match, false);
 


### PR DESCRIPTION
## Checklist

- [x] I have signed the Eclipse Contributor Agreement and linked this GitHub account.
- [x] The commit has a Signed-off-by line using the linked GitHub identity.
- [ ] New feature based on develop — not applicable; this is a bug fix.
- [x] This bug fix is based on the fixes branch.
- [x] The change and rationale are explained below.
- [ ] `make test` — CUnit was unavailable in the verification environment; the relevant topic/ACL unit groups were instead run through a CUnit-compatible local harness as documented below.

## Summary

Fix `%c` and `%u` ACL substitutions when the substituted client ID or username contains `/`.

The 2.1 matcher stopped substitution at the next topic separator, so values such as `device/a` could not match ACL patterns that worked in 2.0.x. The matcher now consumes the full literal substituted value, including hierarchy separators.

To prevent substituted data from being interpreted as MQTT wildcard input, `+` and `#` are rejected anywhere in the substituted client ID or username.

Adds regression coverage for client-ID and username substitutions in both topic and ACL matching.

Fixes #3520.

## Verification

- Unpatched baseline: 12 failures in the focused 14-case regression probe.
- Patched result: 14/14 focused regression cases passed.
- Topic/ACL unit coverage: 30 test groups, 0 assertion failures using a CUnit-compatible local harness because CUnit was unavailable in the verification environment.
- AddressSanitizer and UndefinedBehaviorSanitizer: 30 test groups, 0 assertion failures.
- `git diff --check`: passed.

## AI/GDN disclosure

OpenAI Codex assisted with implementation and test construction. GDN independently reproduced the regression, challenged the wildcard-handling boundary, and verified the final patch against the baseline. I reviewed and understood the changes and approve this contribution. GDN is model-independent and can be used with any AI model.