### PR TITLE
docs: remove unpublished $SYS/broker/mqtt topics from man page

### DIFF
--- a/man/mosquitto.8.xml
+++ b/man/mosquitto.8.xml
@@ -626,19 +626,6 @@
 				</listitem>
 			</varlistentry>
 			<varlistentry>
-				<term><option>$SYS/broker/mqtt/connect/received</option></term>
-				<listitem>
-					<para>The total number of MQTT CONNECT messages received since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/connack/sent</option></term>
-				<listitem>
-					<para>The total number of MQTT CONNACK messages sent since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/publish/dropped</option></term>
 				<term><option>$SYS/broker/publish/messages/dropped</option></term>
 				<listitem>
 					<para>
@@ -651,125 +638,15 @@
 				</listitem>
 			</varlistentry>
 			<varlistentry>
-				<term><option>$SYS/broker/mqtt/publish/received</option></term>
 				<term><option>$SYS/broker/publish/messages/received</option></term>
 				<listitem>
 					<para>The total number of MQTT PUBLISH messages received since the broker started.</para>
 				</listitem>
 			</varlistentry>
 			<varlistentry>
-				<term><option>$SYS/broker/mqtt/publish/sent</option></term>
 				<term><option>$SYS/broker/publish/messages/sent</option></term>
 				<listitem>
 					<para>The total number of MQTT PUBLISH messages sent since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/puback/received</option></term>
-				<listitem>
-					<para>The total number of MQTT PUBACK messages received since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/puback/sent</option></term>
-				<listitem>
-					<para>The total number of MQTT PUBACK messages sent since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/pubrec/received</option></term>
-				<listitem>
-					<para>The total number of MQTT PUBREC messages received since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/pubrec/sent</option></term>
-				<listitem>
-					<para>The total number of MQTT PUBREC messages sent since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/pubrel/received</option></term>
-				<listitem>
-					<para>The total number of MQTT PUBREL messages received since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/pubrel/sent</option></term>
-				<listitem>
-					<para>The total number of MQTT PUBREL messages sent since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/pubcomp/received</option></term>
-				<listitem>
-					<para>The total number of MQTT PUBCOMP messages received since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/pubcomp/sent</option></term>
-				<listitem>
-					<para>The total number of MQTT PUBCOMP messages sent since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/subscribe/received</option></term>
-				<listitem>
-					<para>The total number of MQTT SUBSCRIBE messages received since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/suback/sent</option></term>
-				<listitem>
-					<para>The total number of MQTT SUBACK messages sent since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/unsubscribe/received</option></term>
-				<listitem>
-					<para>The total number of MQTT UNSUBSCRIBE messages received since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/unsuback/sent</option></term>
-				<listitem>
-					<para>The total number of MQTT UNSUBACK messages sent since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/pingreq/received</option></term>
-				<listitem>
-					<para>The total number of MQTT PINGREQ messages received since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/pingresp/sent</option></term>
-				<listitem>
-					<para>The total number of MQTT PINGRESP messages sent since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/disconnect/received</option></term>
-				<listitem>
-					<para>The total number of MQTT DISCONNECT messages received since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/disconnect/sent</option></term>
-				<listitem>
-					<para>The total number of MQTT DISCONNECT messages sent since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/auth/received</option></term>
-				<listitem>
-					<para>The total number of MQTT AUTH messages received since the broker started.</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term><option>$SYS/broker/mqtt/auth/sent</option></term>
-				<listitem>
-					<para>The total number of MQTT AUTH messages sent since the broker started.</para>
 				</listitem>
 			</varlistentry>
 			<varlistentry>


### PR DESCRIPTION
Thank you for contributing your time to the Mosquitto project!

Before you go any further, please note that we cannot accept contributions if you haven't signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [ ] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?

## Summary

The Broker Status section of `mosquitto(8)` listed `$SYS/broker/mqtt/#` packet counters such as `$SYS/broker/mqtt/connect/received`. Those topics are never published: `src/sys_tree.c` leaves their `topic` NULL after commit `04ef5326` ("Not published in $SYS, may be made available for plugins.").

This change removes the unpublished `$SYS/broker/mqtt/...` entries from `man/mosquitto.8.xml` and keeps the `$SYS/broker/publish/messages/{dropped,received,sent}` topics that the broker does publish.

Docs-only. `www/man` is a symlink to `man/`.

Fixes https://github.com/eclipse-mosquitto/mosquitto/issues/3726