### PR TITLE
Fix bridge session expiry at startup before bridges are started

### DIFF
--- a/src/session_expiry.c
+++ b/src/session_expiry.c
@@ -198,7 +198,8 @@ void session_expiry__check(void)
 	last_check = db.now_real_s;
 
 	DL_FOREACH_SAFE(expiry_list, item, tmp){
-		if(item->context->session_expiry_time < db.now_real_s){
+		if(item->context->session_expiry_time < db.now_real_s
+				&& item->context->bridge == NULL){   /* Outgoing bridge connections never expire */
 
 			context = item->context;
 			session_expiry__remove(context);


### PR DESCRIPTION
In 2.1.x, session_expiry__check() was added to broker startup and runs
before bridge__start_all(). This causes restored outgoing bridge sessions
to be incorrectly expired if persistent_client_expiration has passed,
silently discarding the bridge's offline message queue.

Add a bridge guard in session_expiry__check() to skip outgoing bridge
sessions, consistent with the existing 'Outgoing bridge connection never
expire' guard in context__disconnect().

Fixes #3728

- [x] Have you signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php), using the same email address as you used in your commits?
- [x] Do each of your commits have a "Signed-off-by" line, with the correct email address? Use "git commit -s" to generate this line for you.
- [ ] If you are contributing a new feature, is your work based off the develop branch?
- [x] If you are contributing a bugfix, is your work based off the fixes branch?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `make test` with your changes locally?